### PR TITLE
fix: resolve missing profile data on initial launch with unified profile fetch

### DIFF
--- a/app/src/main/java/com/beem/catmap/KullaniciAuth/Kullanici.java
+++ b/app/src/main/java/com/beem/catmap/KullaniciAuth/Kullanici.java
@@ -1,9 +1,6 @@
+
 package com.beem.catmap.KullaniciAuth;
 
-import static android.content.Context.MODE_PRIVATE;
-
-import android.content.Context;
-import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.os.Build;
 
@@ -36,11 +33,13 @@ public class Kullanici {
     private boolean cevrimiciMi = false;
 
     public int TakipEdiyorMuyum=0;
+    private String biyografi= "";
+    private boolean isProfileLoaded = false;
     public int TakipciMi=0;
 
-    private Long takipciSayisi= 0L;
-    private Long takipEdilenSayisi= 0L;
-    private String biyografi= "";
+    private Long takipciSayisi = 0L;
+    private Long takipEdilenSayisi = 0L;
+    private Long gonderiSayisi = 0L;
 
     public Kullanici(String ID, String kullaniciAdi, String ad, String soyad, String biyografi, String fotoUrl) {
         this.ID = ID;
@@ -184,6 +183,23 @@ public class Kullanici {
         Email = email.toLowerCase().trim();
     }
 
+
+    public String getBiyografi() {
+        return biyografi;
+    }
+
+    public void setBiyografi(String biyografi) {
+        this.biyografi = biyografi;
+    }
+
+    public boolean isProfileLoaded() {
+        return isProfileLoaded;
+    }
+
+    public void setProfileLoaded(boolean profileLoaded) {
+        isProfileLoaded = profileLoaded;
+    }
+
     public Long getTakipciSayisi() {
         return takipciSayisi;
     }
@@ -200,12 +216,28 @@ public class Kullanici {
         this.takipEdilenSayisi = takipEdilenSayisi;
     }
 
-    public String getBiyografi() {
-        return biyografi;
+    public Long getGonderiSayisi() {
+        return gonderiSayisi;
     }
 
-    public void setBiyografi(String biyografi) {
-        this.biyografi = biyografi;
+    public void setGonderiSayisi(Long gonderiSayisi) {
+        this.gonderiSayisi = gonderiSayisi;
+    }
+
+    public int getTakipEdiyorMuyum() {
+        return TakipEdiyorMuyum;
+    }
+
+    public void setTakipEdiyorMuyum(int takipEdiyorMuyum) {
+        TakipEdiyorMuyum = takipEdiyorMuyum;
+    }
+
+    public int getTakipciMi() {
+        return TakipciMi;
+    }
+
+    public void setTakipciMi(int takipciMi) {
+        TakipciMi = takipciMi;
     }
 
     public boolean KullaniciIs(){
@@ -232,14 +264,6 @@ public class Kullanici {
         return kullaniciData;
     }
 
-    public void GetYerelKullanici(Context baglanti){
-        SharedPreferences kayit = baglanti.getSharedPreferences("KullaniciKayit",MODE_PRIVATE);
-        this.ID = kayit.getString("ID","");
-        this.Ad = kayit.getString("Ad","");
-        this.Soyad = kayit.getString("Soyad","");
-        this.Email = kayit.getString("Email","");
-        this.KullaniciAdi = kayit.getString("KullaniciAdi","");
-        this.Sifre = kayit.getString("Sifre","");
-    }
+
 
 }

--- a/app/src/main/java/com/beem/catmap/Profil/ProfilSayfasiFragment.java
+++ b/app/src/main/java/com/beem/catmap/Profil/ProfilSayfasiFragment.java
@@ -1,5 +1,5 @@
 package com.beem.catmap.Profil;
-
+/*
 import static android.app.Activity.RESULT_OK;
 import static android.content.Context.MODE_PRIVATE;
 

--- a/app/src/main/java/com/beem/catmap/data/model/FollowCounts.kt
+++ b/app/src/main/java/com/beem/catmap/data/model/FollowCounts.kt
@@ -1,0 +1,6 @@
+package com.beem.catmap.data.model
+
+data class FollowCounts(
+    val followingCount: Long = 0L,
+    val followerCount: Long = 0L
+)

--- a/app/src/main/java/com/beem/catmap/data/model/FullProfileData.kt
+++ b/app/src/main/java/com/beem/catmap/data/model/FullProfileData.kt
@@ -8,5 +8,6 @@ data class FullProfileData(
     val postsCache: ProfilePostCacheData,
     val followerCount: Long,
     val followingCount: Long,
+    val postCount:Long,
     val isSelfProfile: Boolean,
 )

--- a/app/src/main/java/com/beem/catmap/data/model/FullProfileData.kt
+++ b/app/src/main/java/com/beem/catmap/data/model/FullProfileData.kt
@@ -1,0 +1,12 @@
+package com.beem.catmap.data.model
+
+import com.beem.catmap.gonderi.ProfilePostCacheData
+import com.beem.catmap.gonderi.UserProfileData
+
+data class FullProfileData(
+    val profile: UserProfileData,
+    val postsCache: ProfilePostCacheData,
+    val followerCount: Long,
+    val followingCount: Long,
+    val isSelfProfile: Boolean,
+)

--- a/app/src/main/java/com/beem/catmap/data/repository/FollowRepository.kt
+++ b/app/src/main/java/com/beem/catmap/data/repository/FollowRepository.kt
@@ -1,21 +1,28 @@
-package com.beem.catmap.data.repository;
+package com.beem.catmap.data.repository
+
 import android.content.Context
-import androidx.core.content.edit
+import androidx.collection.LruCache
 import com.beem.catmap.data.local.UserSession
+import com.beem.catmap.data.session.CurrentUserManager
+import com.beem.catmap.gonderi.TargetUserFollowData
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
 import kotlin.math.max
-
-class FollowRepository(
-) {
+class FollowRepository(private val context: Context) {
     private val db: FirebaseFirestore = FirebaseFirestore.getInstance()
+    private val userManager = CurrentUserManager.getInstance(context)
+
+    private val targetUserCache = LruCache<String, TargetUserFollowData>(10)
+
     private val currentUserId: String?
         get() = UserSession.userId
-    //benım takıp ettıklşerım
-    suspend fun isFollowing(targetUserId: String): Result<Boolean> {
-        val userId = currentUserId ?: return Result.failure(Exception("Oturum açık değil"))
-        return try {
+
+    suspend fun isFollowing(targetUserId: String): Result<Boolean> = withContext(Dispatchers.IO) {
+        val userId = currentUserId ?: return@withContext Result.failure(Exception("Oturum açık değil"))
+        return@withContext try {
             val documentSnapshot = db.collection("users")
                 .document(userId)
                 .collection("takipEdilenler")
@@ -28,11 +35,11 @@ class FollowRepository(
             Result.failure(e)
         }
     }
-    //benı takıp edenler
-    suspend fun isFollowedBy(targetUserId: String): Result<Boolean> {
-        val userId = currentUserId ?: return Result.failure(Exception("Oturum açık değil"))
 
-        return try {
+    suspend fun isFollowedBy(targetUserId: String): Result<Boolean> = withContext(Dispatchers.IO) {
+        val userId = currentUserId ?: return@withContext Result.failure(Exception("Oturum açık değil"))
+
+        return@withContext try {
             val documentSnapshot = db.collection("users")
                 .document(userId)
                 .collection("takipciler")
@@ -45,23 +52,73 @@ class FollowRepository(
             Result.failure(e)
         }
     }
+
+    suspend fun fetchAndCacheFollowCounts(
+        userId: String,
+        isMyProfile: Boolean,
+        forceRefresh: Boolean = false
+    ): Result<FollowCounts> = withContext(Dispatchers.IO) {
+
+        if (isMyProfile && !forceRefresh) {
+            val followerCount = userManager.profileState.value.takipciSayisi
+            val followingCount = userManager.profileState.value.takipEdilenSayisi
+            return@withContext Result.success(FollowCounts(followingCount, followerCount))
+        }
+
+        if (!isMyProfile && !forceRefresh) {
+            val cachedData = targetUserCache.get(userId)
+            if (cachedData != null) {
+                return@withContext Result.success(FollowCounts(cachedData.followingCount, cachedData.followerCount))
+            }
+        }
+
+        try {
+            val snapshot = db.collection("users")
+                .document(userId)
+                .get()
+                .await()
+
+            if (snapshot.exists()) {
+                val followingCount = snapshot.getLong("TakipEdilenSayisi") ?: 0L
+                val followerCount = snapshot.getLong("takipciSayisi") ?: 0L
+
+                if (isMyProfile) {
+                    userManager.updateFollowCounts(followerCount, followingCount)
+                } else {
+                    targetUserCache.put(userId, TargetUserFollowData(followerCount, followingCount))
+                }
+
+                Result.success(FollowCounts(followingCount, followerCount))
+            } else {
+                Result.success(FollowCounts(0L, 0L))
+            }
+        } catch (e: Exception) {
+            if (!isMyProfile) {
+                val cached = targetUserCache.get(userId)
+                if (cached != null) {
+                    return@withContext Result.success(FollowCounts(cached.followingCount, cached.followerCount))
+                }
+            }
+            Result.failure(e)
+        }
+    }
+
     suspend fun takipet(
         currentUserId: String,
         targetUserId: String,
         myBlockedList: List<String>?,
         blockedMeList: List<String>?
-    ): Result<Unit> {
-        // Engelleme kontrolleri
+    ): Result<Unit> = withContext(Dispatchers.IO) {
         if ((myBlockedList?.contains(targetUserId) == true) ||
             (blockedMeList?.contains(currentUserId) == true)
         ) {
-            return Result.failure(IllegalStateException("Engelleme durumundan dolayı takip edilemez."))
+            return@withContext Result.failure(IllegalStateException("Engelleme durumundan dolayı takip edilemez."))
         }
 
         val currentUserRef = db.collection("users").document(currentUserId)
         val targetUserRef = db.collection("users").document(targetUserId)
 
-        return try {
+        return@withContext try {
             db.runTransaction { transaction ->
                 val currentSnap = transaction.get(currentUserRef)
                 val targetSnap = transaction.get(targetUserRef)
@@ -111,16 +168,28 @@ class FollowRepository(
                 null
             }.await()
 
+            // Target Cache güncelleme
+            val currentCache = targetUserCache.get(targetUserId)
+            val newFollowerCount = (currentCache?.followerCount ?: 0L) + 1
+            val newFollowingCount = currentCache?.followingCount ?: 0L
+            targetUserCache.put(targetUserId, TargetUserFollowData(newFollowerCount, newFollowingCount))
+
+            // Kendi profil sayılarını güncelleme
+            val myCurrentFollower = userManager.profileState.value.takipciSayisi
+            val myCurrentFollowing = userManager.profileState.value.takipEdilenSayisi
+            userManager.updateFollowCounts(myCurrentFollower, myCurrentFollowing + 1)
+
             Result.success(Unit)
         } catch (e: Exception) {
             Result.failure(e)
         }
-    }// --- YENİ: TAKİPTEN ÇIKARMA METODU ---
-    suspend fun unfollowUser(currentUserId: String, targetUserId: String): Result<Unit> {
+    }
+
+    suspend fun unfollowUser(currentUserId: String, targetUserId: String): Result<Unit> = withContext(Dispatchers.IO) {
         val currentUserRef = db.collection("users").document(currentUserId)
         val targetUserRef = db.collection("users").document(targetUserId)
 
-        return try {
+        return@withContext try {
             db.runTransaction { transaction ->
                 val currentSnap = transaction.get(currentUserRef)
                 val targetSnap = transaction.get(targetUserRef)
@@ -155,18 +224,29 @@ class FollowRepository(
                 null
             }.await()
 
+            // Target Cache güncelleme
+            val currentCache = targetUserCache.get(targetUserId)
+            if (currentCache != null) {
+                val newFollowerCount = max(currentCache.followerCount - 1, 0L)
+                targetUserCache.put(targetUserId, TargetUserFollowData(newFollowerCount, currentCache.followingCount))
+            }
+
+            // Kendi profil sayılarını güncelleme
+            val myCurrentFollower = userManager.profileState.value.takipciSayisi
+            val myCurrentFollowing = max(userManager.profileState.value.takipEdilenSayisi - 1, 0L)
+            userManager.updateFollowCounts(myCurrentFollower, myCurrentFollowing)
+
             Result.success(Unit)
         } catch (e: Exception) {
             Result.failure(e)
         }
     }
 
-    // --- YENİ: TAKİPÇİDEN ÇIKARMA (TAKİPÇİYİ SİLME) METODU ---
-    suspend fun removeFollower(currentUserId: String, followerId: String): Result<Unit> {
+    suspend fun removeFollower(currentUserId: String, followerId: String): Result<Unit> = withContext(Dispatchers.IO) {
         val currentUserRef = db.collection("users").document(currentUserId)
         val followerRef = db.collection("users").document(followerId)
 
-        return try {
+        return@withContext try {
             db.runTransaction { transaction ->
                 val currentSnap = transaction.get(currentUserRef)
                 val followerSnap = transaction.get(followerRef)
@@ -201,36 +281,17 @@ class FollowRepository(
                 null
             }.await()
 
+            val myCurrentFollower = max(userManager.profileState.value.takipciSayisi - 1, 0L)
+            val myCurrentFollowing = userManager.profileState.value.takipEdilenSayisi
+            userManager.updateFollowCounts(myCurrentFollower, myCurrentFollowing)
+
             Result.success(Unit)
         } catch (e: Exception) {
             Result.failure(e)
         }
     }
 
-    suspend fun fetchAndCacheFollowCounts(context: Context, userId: String): Result<FollowCounts> {
-        return try {
-            val snapshot = db.collection("users")
-                .document(userId)
-                .get()
-                .await()
-
-            if (snapshot.exists()) {
-                val followingCount = snapshot.getLong("TakipEdilenSayisi") ?: 0L
-                val followerCount = snapshot.getLong("takipciSayisi") ?: 0L
-
-                // SharedPreferences önbellekleme
-                val sp = context.getSharedPreferences("ProfilPrefs", Context.MODE_PRIVATE)
-                sp.edit {
-                    putLong("cache_takip", followingCount)
-                    putLong("cache_takipci", followerCount)
-                }
-
-                Result.success(FollowCounts(followingCount, followerCount))
-            } else {
-                Result.success(FollowCounts(0L, 0L))
-            }
-        } catch (e: Exception) {
-            Result.failure(e)
-        }
+    fun getCachedTargetUserData(userId: String): TargetUserFollowData? {
+        return targetUserCache.get(userId)
     }
 }

--- a/app/src/main/java/com/beem/catmap/data/repository/PostRepo.kt
+++ b/app/src/main/java/com/beem/catmap/data/repository/PostRepo.kt
@@ -1,71 +1,69 @@
 package com.beem.catmap.data.repository
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.util.Log
 import androidx.collection.LruCache
+import com.beem.catmap.data.local.UserSession
+import com.beem.catmap.data.session.CurrentUserManager
 import com.beem.catmap.gonderi.ProfilePostCacheData
 import com.beem.catmap.models.Gonderi
 import com.beem.catmap.models.GonderilenKediItem
 import com.google.firebase.Timestamp
+import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FieldPath
-import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
+import kotlin.math.max
 
-object PostRepository {
+class PostRepository(private val context: Context) {
     @SuppressLint("StaticFieldLeak")
     private val db = FirebaseFirestore.getInstance()
     private val usersCollection = db.collection("users")
     private val catsCollection = db.collection("cats")
 
+    private val userManager = CurrentUserManager.getInstance(context)
+
     private val profileCache = LruCache<String, ProfilePostCacheData>(5)
-    private const val PAGE_SIZE = 10
+    private val PAGE_SIZE = 10L
 
-    // Önbellekte yer alan veriyi ViewModel'a hazır sunmak için yardımcı metot
-    fun getCachedProfileData(userId: String): ProfilePostCacheData? {
-        return profileCache.get(userId)
-    }
+    // Son çekilen belgeyi tutmak için sayfalama takibi (UserId -> LastDocument)
+    private val lastDocumentMap = mutableMapOf<String, DocumentSnapshot?>()
 
-    // İlgili kullanıcının sayfalama sonuna ulaşıp ulaşmadığını döndürür
+
     fun isLastPage(userId: String): Boolean {
         return profileCache.get(userId)?.isLastPage ?: false
     }
 
-    // Kullanıcının profilindeki tüm kedi ID ve tarihlerini 1 KERE çeker
     suspend fun getKullaniciGonderiIdListesi(userId: String): Result<List<GonderilenKediItem>> {
         return try {
             val snapshot = usersCollection
                 .document(userId)
+                .collection("GonderilenKediler")
+                .orderBy("tarih", Query.Direction.DESCENDING)
                 .get()
                 .await()
 
-            if (!snapshot.exists()) {
-                Result.success(emptyList())
-            } else {
-                val rawList = snapshot.get("GonderilenKediler") as? List<Map<String, Any>> ?: emptyList()
-                val items = rawList.mapNotNull { map ->
-                    val kediID = map["kediID"] as? String
-                    val tarih = map["tarih"] as? Timestamp
-                    if (kediID != null) {
-                        GonderilenKediItem(kediID = kediID, tarih = tarih)
-                    } else {
-                        null
-                    }
-                }.sortedByDescending { it.tarih } // En yeni en üstte
-
-                Result.success(items)
+            val items = snapshot.documents.mapNotNull { doc ->
+                val kediID = doc.getString("kediID")
+                val tarih = doc.getTimestamp("tarih")
+                if (kediID != null) GonderilenKediItem(kediID = kediID, tarih = tarih) else null
             }
+
+            Result.success(items)
         } catch (e: Exception) {
             Log.e("PostRepository", "Kullanıcı kedi ID listesi alınamadı: ${e.message}")
             Result.failure(e)
         }
     }
 
+    // İlk sayfayı Firestore Alt Koleksiyonundan çeker
     suspend fun getUserPosts(
         userId: String,
         forceRefresh: Boolean = false
@@ -78,36 +76,44 @@ object PostRepository {
             return@withContext Result.success(cachedData)
         }
 
+        lastDocumentMap[userId] = null
+
         try {
-            val snapshot = usersCollection.document(userId).get().await()
-            val rawList = snapshot.get("GonderilenKediler") as? List<Map<String, Any>> ?: emptyList()
+            val query = usersCollection
+                .document(userId)
+                .collection("GonderilenKediler")
+                .orderBy("tarih", Query.Direction.DESCENDING)
+                .limit(PAGE_SIZE)
 
-            val fullIdList = rawList.mapNotNull { map ->
-                val kediID = map["kediID"] as? String
-                val tarih = map["tarih"] as? Timestamp
-                if (kediID != null) GonderilenKediItem(kediID = kediID, tarih = tarih) else null
-            }.sortedByDescending { it.tarih }
+            val snapshot = query.get().await()
 
-            if (fullIdList.isEmpty()) {
+            if (snapshot.isEmpty) {
                 val emptyCache = ProfilePostCacheData(emptyList(), emptyList(), 0, true)
                 profileCache.put(userId, emptyCache)
+                lastDocumentMap[userId] = null
                 return@withContext Result.success(emptyCache)
             }
 
-            val firstBatch = fullIdList.take(PAGE_SIZE)
-            val isLast = firstBatch.size >= fullIdList.size
-            val gonderiler = fetchGonderilerByIdsInternal(firstBatch)
+            // Son belgeyi sayfalama için kaydet
+            lastDocumentMap[userId] = snapshot.documents.lastOrNull()
+
+            val batchItems = snapshot.documents.mapNotNull { doc ->
+                val kediID = doc.getString("kediID")
+                val tarih = doc.getTimestamp("tarih")
+                if (kediID != null) GonderilenKediItem(kediID = kediID, tarih = tarih) else null
+            }
+
+            val isLast = snapshot.size() < PAGE_SIZE
+            val gonderiler = fetchGonderilerByIdsInternal(batchItems)
 
             val newCacheData = ProfilePostCacheData(
                 posts = gonderiler,
-                idList = fullIdList,
-                offset = firstBatch.size,
+                idList = batchItems,
+                offset = batchItems.size,
                 isLastPage = isLast
             )
 
             profileCache.put(userId, newCacheData)
-            Log.d("POST_REPO_DEBUG", "Veriler FIRESTORE'dan çekilip ÖNBELLEĞE yazıldı.")
-
             Result.success(newCacheData)
         } catch (e: Exception) {
             Log.e("POST_REPO_DEBUG", "Gönderiler çekilirken hata: ${e.message}")
@@ -115,27 +121,55 @@ object PostRepository {
         }
     }
 
+    // Sayfalama (Pagination): Son kalınan belgeden itibaren sonraki PAGE_SIZE kadar veriyi çeker
     suspend fun dahaFazlaGonderiGetir(userId: String): Result<ProfilePostCacheData> = withContext(Dispatchers.IO) {
         val cachedData = profileCache.get(userId)
             ?: return@withContext Result.failure(Exception("Önbellek bulunamadı!"))
 
-        if (cachedData.isLastPage || cachedData.offset >= cachedData.idList.size) {
+        val lastDoc = lastDocumentMap[userId]
+        if (cachedData.isLastPage || lastDoc == null) {
             return@withContext Result.success(cachedData)
         }
 
         try {
-            val currentOffset = cachedData.offset
-            val nextOffset = (currentOffset + PAGE_SIZE).coerceAtMost(cachedData.idList.size)
-            val nextBatch = cachedData.idList.subList(currentOffset, nextOffset)
-            val isLast = nextOffset >= cachedData.idList.size
+            val query = usersCollection
+                .document(userId)
+                .collection("GonderilenKediler")
+                .orderBy("tarih", Query.Direction.DESCENDING)
+                .startAfter(lastDoc)
+                .limit(PAGE_SIZE)
 
-            val newGonderiler = fetchGonderilerByIdsInternal(nextBatch)
+            val snapshot = query.get().await()
+
+            if (snapshot.isEmpty) {
+                val updatedCache = ProfilePostCacheData(
+                    posts = cachedData.posts,
+                    idList = cachedData.idList,
+                    offset = cachedData.offset,
+                    isLastPage = true
+                )
+                profileCache.put(userId, updatedCache)
+                return@withContext Result.success(updatedCache)
+            }
+
+            lastDocumentMap[userId] = snapshot.documents.lastOrNull()
+
+            val newBatchItems = snapshot.documents.mapNotNull { doc ->
+                val kediID = doc.getString("kediID")
+                val tarih = doc.getTimestamp("tarih")
+                if (kediID != null) GonderilenKediItem(kediID = kediID, tarih = tarih) else null
+            }
+
+            val isLast = snapshot.size() < PAGE_SIZE
+            val newGonderiler = fetchGonderilerByIdsInternal(newBatchItems)
+
             val updatedPosts = cachedData.posts + newGonderiler
+            val updatedIdList = cachedData.idList + newBatchItems
 
             val updatedCache = ProfilePostCacheData(
                 posts = updatedPosts,
-                idList = cachedData.idList,
-                offset = nextOffset,
+                idList = updatedIdList,
+                offset = updatedPosts.size,
                 isLastPage = isLast
             )
 
@@ -150,58 +184,49 @@ object PostRepository {
         if (items.isEmpty()) return Result.success(emptyList())
 
         return try {
-            val tarihMap = items.associate { it.kediID to it.tarih }
-            val kediIds = items.map { it.kediID }.distinct()
-            val chunks = kediIds.chunked(30)
-
-            val gonderiler = coroutineScope {
-                chunks.map { chunk ->
-                    async {
-                        val snapshot = catsCollection
-                            .whereIn(FieldPath.documentId(), chunk)
-                            .get()
-                            .await()
-
-                        snapshot.documents.mapNotNull { doc ->
-                            val fotoList = doc.get("photoUri") as? List<String> ?: emptyList()
-                            if (fotoList.isEmpty()) return@mapNotNull null
-
-                            Gonderi(
-                                kediID = doc.id,
-                                fotoUrlListesi = fotoList,
-                                aciklama = doc.getString("kediHakkinda"),
-                                kediAdi = doc.getString("kediAdi"),
-                                tarih = tarihMap[doc.id],
-                                begeniSayisi = doc.getLong("begeniSayisi") ?: 0L
-                            )
-                        }
-                    }
-                }.awaitAll().flatten()
-            }
-
-            val sortedList = gonderiler.sortedByDescending { it.tarih }
-            Result.success(sortedList)
+            val gonderiler = fetchGonderilerByIdsInternal(items)
+            Result.success(gonderiler)
         } catch (e: Exception) {
             Log.e("PostRepository", "Gönderi detayları çekilirken hata: ${e.message}")
             Result.failure(e)
         }
     }
 
-    suspend fun kullaniciGonderiSil(userId: String, kediId: String): Result<Unit> = withContext(Dispatchers.IO) {
+    suspend fun kullaniciGonderiSil(
+        userId: String,
+        kediId: String
+    ): Result<Unit> = withContext(Dispatchers.IO) {
         try {
-            val snapshot = usersCollection.document(userId).get().await()
-            val rawList = snapshot.get("GonderilenKediler") as? List<Map<String, Any>> ?: emptyList()
-            val silinecek = rawList.firstOrNull { it["kediID"] == kediId }
-                ?: throw Exception("Silinecek gönderi bulunamadı.")
+            val userRef = usersCollection.document(userId)
+            val subCollRef = userRef.collection("GonderilenKediler")
 
-            usersCollection.document(userId)
-                .update("GonderilenKediler", FieldValue.arrayRemove(silinecek))
-                .await()
+            val querySnapshot = subCollRef.whereEqualTo("kediID", kediId).get().await()
 
+            db.runTransaction { transaction ->
+                val userSnap = transaction.get(userRef)
+                val currentPostCount = userSnap.getLong("gonderiSayisi") ?: 0L
+
+                for (doc in querySnapshot.documents) {
+                    transaction.delete(doc.reference)
+                }
+
+                if (querySnapshot.documents.isNotEmpty()) {
+                    val newCount = max(currentPostCount - 1, 0L)
+                    transaction.update(userRef, "gonderiSayisi", newCount)
+                }
+                null
+            }.await()
+
+            // Local cache ve session güncellemesi
             removePostFromCacheInternal(userId, kediId)
 
+            if (userId == UserSession.userId) {
+                val currentCount = userManager.profileState.value.gonderiSayisi
+                userManager.updateGonderiSayisi(max(currentCount - 1, 0L))
+            }
             Result.success(Unit)
         } catch (e: Exception) {
+            Log.e("PostRepository", "Gönderi silinirken hata: ${e.message}")
             Result.failure(e)
         }
     }
@@ -210,20 +235,39 @@ object PostRepository {
         catsCollection.document(kediId).delete().await()
     }
 
-    suspend fun kullaniciGonderiKaydet(userId: String, kediId: String): Result<Unit> = withContext(Dispatchers.IO) {
+    suspend fun kullaniciGonderiKaydet(
+        userId: String,
+        kediId: String
+    ): Result<Unit> = withContext(Dispatchers.IO) {
         try {
-            val yeniKedi = mapOf(
+            val userRef = usersCollection.document(userId)
+            val subCollRef = userRef.collection("GonderilenKediler")
+
+            val yeniKediDoc = subCollRef.document()
+            val yeniKediData = mapOf(
                 "kediID" to kediId,
                 "tarih" to Timestamp.now()
             )
-            usersCollection.document(userId)
-                .update("GonderilenKediler", FieldValue.arrayUnion(yeniKedi))
-                .await()
+
+            db.runTransaction { transaction ->
+                val userSnap = transaction.get(userRef)
+                val currentPostCount = userSnap.getLong("gonderiSayisi") ?: 0L
+
+                transaction.set(yeniKediDoc, yeniKediData)
+                transaction.update(userRef, "gonderiSayisi", currentPostCount + 1)
+                null
+            }.await()
 
             addPostToCacheInternal(userId, kediId)
 
+            if (userId == UserSession.userId) {
+                val currentCount = userManager.profileState.value.gonderiSayisi
+                userManager.updateGonderiSayisi(currentCount + 1)
+            }
+
             Result.success(Unit)
         } catch (e: Exception) {
+            Log.e("PostRepository", "Gönderi kaydedilirken hata: ${e.message}")
             Result.failure(e)
         }
     }
@@ -245,14 +289,12 @@ object PostRepository {
         val cachedData = profileCache.get(userId) ?: return
         val yeniKediItem = GonderilenKediItem(kediID = kediId, tarih = Timestamp.now())
         val updatedIdList = listOf(yeniKediItem) + cachedData.idList
-        val firstBatchIds = updatedIdList.take(PAGE_SIZE)
 
-        val yeniListe = fetchGonderilerByIdsInternal(firstBatchIds)
-        val isLast = firstBatchIds.size >= updatedIdList.size
+        val yeniListe = fetchGonderilerByIdsInternal(listOf(yeniKediItem)) + cachedData.posts
 
         profileCache.put(
             userId,
-            ProfilePostCacheData(yeniListe, updatedIdList, firstBatchIds.size, isLast)
+            ProfilePostCacheData(yeniListe, updatedIdList, cachedData.offset + 1, cachedData.isLastPage)
         )
     }
 

--- a/app/src/main/java/com/beem/catmap/data/repository/PostRepo.kt
+++ b/app/src/main/java/com/beem/catmap/data/repository/PostRepo.kt
@@ -24,7 +24,17 @@ object PostRepository {
     private val catsCollection = db.collection("cats")
 
     private val profileCache = LruCache<String, ProfilePostCacheData>(5)
-    private val PAGE_SIZE = 10
+    private const val PAGE_SIZE = 10
+
+    // Önbellekte yer alan veriyi ViewModel'a hazır sunmak için yardımcı metot
+    fun getCachedProfileData(userId: String): ProfilePostCacheData? {
+        return profileCache.get(userId)
+    }
+
+    // İlgili kullanıcının sayfalama sonuna ulaşıp ulaşmadığını döndürür
+    fun isLastPage(userId: String): Boolean {
+        return profileCache.get(userId)?.isLastPage ?: false
+    }
 
     // Kullanıcının profilindeki tüm kedi ID ve tarihlerini 1 KERE çeker
     suspend fun getKullaniciGonderiIdListesi(userId: String): Result<List<GonderilenKediItem>> {
@@ -84,7 +94,6 @@ object PostRepository {
                 return@withContext Result.success(emptyCache)
             }
 
-            // 2. İlk batch'i çek
             val firstBatch = fullIdList.take(PAGE_SIZE)
             val isLast = firstBatch.size >= fullIdList.size
             val gonderiler = fetchGonderilerByIdsInternal(firstBatch)

--- a/app/src/main/java/com/beem/catmap/data/session/CurrentUserManager.kt
+++ b/app/src/main/java/com/beem/catmap/data/session/CurrentUserManager.kt
@@ -1,35 +1,58 @@
 package com.beem.catmap.data.session
-
 import android.content.Context
 import com.beem.catmap.KullaniciAuth.Kullanici
 import com.beem.catmap.gonderi.ProfileState
+import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
-import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 
 class CurrentUserManager private constructor(context: Context) {
 
     private val sessionManager = UserSessionManager.getInstance(context)
-    private val profileSessionManager = ProfileSessionManager.getInstance(context)
-    private val blockSessionManager = BlockSessionManager.getInstance(context) // <-- Eklendi
+    private val blockSessionManager = BlockSessionManager.getInstance(context)
 
-    private var currentUserCache: Kullanici? = null
+    // Manager yaşam döngüsüne bağlı coroutine scope
+    private val managerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
-    // --- STATEFLOW TANIMLAMALARI ---
-    private val _profileState = MutableStateFlow(
-        ProfileState(
-            takipciSayisi = profileSessionManager.getTakipciSayisi(),
-            takipEdilenSayisi = profileSessionManager.getTakipEdilenSayisi(),
-            gonderiSayisi = profileSessionManager.getGonderiSayisi(),
-            biyografi = profileSessionManager.getBiyografi()
-        )
+    // --- TEK VERİ KAYNAĞI (SINGLE SOURCE OF TRUTH) ---
+    private val _currentUserState = MutableStateFlow(
+        if (FirebaseAuth.getInstance().currentUser != null) {
+            sessionManager.getUserSession() ?: Kullanici()
+        } else {
+            Kullanici()
+        }
     )
-    val profileState: StateFlow<ProfileState> = _profileState.asStateFlow()
+    val currentUserState: StateFlow<Kullanici> = _currentUserState.asStateFlow()
+
+    // profileState, currentUserState'teki değişikliklerde ad, soyad ve kullaniciAdi ile otomatik güncellenir
+    val profileState: StateFlow<ProfileState> = _currentUserState.map { user ->
+        ProfileState(
+            ad = user.ad,
+            soyad = user.soyad,
+            kullaniciAdi = user.kullaniciAdi,
+            takipciSayisi = user.takipciSayisi ?: 0L,
+            takipEdilenSayisi = user.takipEdilenSayisi ?: 0L,
+            gonderiSayisi = user.gonderiSayisi ?: 0L,
+            biyografi = user.biyografi,
+            fotoUrl = user.fotoUrl
+        )
+    }.stateIn(
+        scope = managerScope,
+        started = SharingStarted.Eagerly,
+        initialValue = ProfileState()
+    )
 
     private val _benimEngellediklerimState = MutableStateFlow(blockSessionManager.getBenimEngellediklerim())
     val benimEngellediklerimState: StateFlow<List<String>> = _benimEngellediklerimState.asStateFlow()
+
+    private var blockedUsersLoaded = false
 
     companion object {
         @Volatile
@@ -42,16 +65,14 @@ class CurrentUserManager private constructor(context: Context) {
         }
     }
 
+    // --- KULLANICI ERİŞİM VE GÜNCELLEME İŞLEMLERİ ---
+
     fun getCurrentUser(): Kullanici {
         if (FirebaseAuth.getInstance().currentUser == null) {
             clearLocalCache()
             return Kullanici()
         }
-
-        if (currentUserCache == null) {
-            currentUserCache = sessionManager.getUserSession()
-        }
-        return currentUserCache ?: Kullanici()
+        return _currentUserState.value
     }
 
     fun getCurrentUserId(): String {
@@ -59,82 +80,95 @@ class CurrentUserManager private constructor(context: Context) {
     }
 
     fun setCurrentUser(kullanici: Kullanici) {
-        this.currentUserCache = kullanici
         sessionManager.saveUserSession(kullanici)
+        _currentUserState.value = kullanici
     }
 
     fun isUserLoggedIn(): Boolean {
         return FirebaseAuth.getInstance().currentUser != null && sessionManager.isLoggedIn()
     }
 
+    /**
+     * Kullanıcı nesnesinin belirli alanlarını güvenli bir şekilde güncellemek için yardımcı metot.
+     */
+    fun updateCurrentUser(updateBlock: (Kullanici) -> Unit) {
+        val currentUser = _currentUserState.value
+        updateBlock(currentUser)
+        setCurrentUser(currentUser)
+    }
+
+    // --- ALAN BAZLI GÜNCELLEMELER ---
 
     fun updateProfileDetails(
-        takipci: Long,
-        takipEdilen: Long,
-        gonderiSayisi: Long = 0L,
-        biyografi: String? = null
+        ad: String? = null,
+        soyad: String? = null,
+        kullaniciAdi: String? = null,
+        takipci: Long? = null,
+        takipEdilen: Long? = null,
+        gonderiSayisi: Long? = null,
+        biyografi: String? = null,
+        fotoUrl: String? = null
     ) {
-        profileSessionManager.saveProfileDetails(
-            takipciSayisi = takipci,
-            takipEdilenSayisi = takipEdilen,
-            gonderiSayisi = gonderiSayisi,
-            biyografi = biyografi
-        )
+        updateCurrentUser { user ->
+            if (ad != null) user.ad = ad
+            if (soyad != null) user.soyad = soyad
+            if (kullaniciAdi != null) user.kullaniciAdi = kullaniciAdi
+            if (takipci != null) user.takipciSayisi = takipci
+            if (takipEdilen != null) user.takipEdilenSayisi = takipEdilen
+            if (gonderiSayisi != null) user.gonderiSayisi = gonderiSayisi
+            if (biyografi != null) user.biyografi = biyografi
+            if (fotoUrl != null) user.fotoUrl = fotoUrl
+        }
+    }
 
-        _profileState.update { currentState ->
-            currentState.copy(
-                takipciSayisi = takipci,
-                takipEdilenSayisi = takipEdilen,
-                gonderiSayisi = gonderiSayisi,
-                biyografi = biyografi ?: currentState.biyografi
-            )
+    fun updateUserInfo(ad: String, soyad: String, kullaniciAdi: String) {
+        updateCurrentUser { user ->
+            user.ad = ad
+            user.soyad = soyad
+            user.kullaniciAdi = kullaniciAdi
         }
     }
 
     fun updateFollowCounts(takipciSayisi: Long, takipEdilenSayisi: Long) {
-        profileSessionManager.saveFollowCounts(takipciSayisi, takipEdilenSayisi)
-
-        _profileState.update { currentState ->
-            currentState.copy(
-                takipciSayisi = takipciSayisi,
-                takipEdilenSayisi = takipEdilenSayisi
-            )
+        updateCurrentUser { user ->
+            user.takipciSayisi = takipciSayisi
+            user.takipEdilenSayisi = takipEdilenSayisi
         }
     }
 
     fun updateGonderiSayisi(gonderiSayisi: Long) {
-        profileSessionManager.saveGonderiSayisi(gonderiSayisi)
-
-        _profileState.update { currentState ->
-            currentState.copy(gonderiSayisi = gonderiSayisi)
+        updateCurrentUser { user ->
+            user.gonderiSayisi = gonderiSayisi
         }
     }
 
     fun updateBiyografi(biyografi: String) {
-        profileSessionManager.saveBiyografi(biyografi)
-
-        _profileState.update { currentState ->
-            currentState.copy(biyografi = biyografi)
+        updateCurrentUser { user ->
+            user.biyografi = biyografi
         }
     }
 
-    /**
-     * Engellenenler listesini hem SharedPreferences'a yazar hem de Flow'u günceller.
-     */
-    private var blockedUsersLoaded = false
+    fun updateFotoUrl(fotoUrl: String) {
+        updateCurrentUser { user ->
+            user.fotoUrl = fotoUrl
+        }
+    }
+
+    // --- ENGELLEME YÖNETİMİ ---
 
     fun isBlockedUsersLoaded(): Boolean = blockedUsersLoaded
 
     fun setBlockedUsersLoaded(loaded: Boolean) {
         blockedUsersLoaded = loaded
     }
+
     fun updateBenimEngellediklerim(liste: List<String>) {
         blockSessionManager.saveBenimEngellediklerim(liste)
         _benimEngellediklerimState.value = liste
         blockedUsersLoaded = true
     }
 
-    // --- ÇIKIŞ YAP (LOGOUT) ---
+    // --- LOGOUT / SIFIRLAMA ---
 
     fun logout() {
         FirebaseAuth.getInstance().signOut()
@@ -142,12 +176,10 @@ class CurrentUserManager private constructor(context: Context) {
     }
 
     fun clearLocalCache() {
-        currentUserCache = null
         sessionManager.clearSession()
-        profileSessionManager.clearProfileCache()
         blockSessionManager.clearBlockCache()
 
-        _profileState.value = ProfileState()
+        _currentUserState.value = Kullanici()
         _benimEngellediklerimState.value = emptyList()
 
         blockedUsersLoaded = false

--- a/app/src/main/java/com/beem/catmap/gonderi/FollowViewModel.kt
+++ b/app/src/main/java/com/beem/catmap/gonderi/FollowViewModel.kt
@@ -1,7 +1,6 @@
 package com.beem.catmap.gonderi
 
 import android.app.Application
-import androidx.collection.LruCache
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.beem.catmap.data.local.UserSession
@@ -13,15 +12,12 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-
 class FollowViewModel(application: Application) : AndroidViewModel(application) {
 
-    private val repository: FollowRepository = FollowRepository()
+    private val repository: FollowRepository = FollowRepository(application)
     private val userManager = CurrentUserManager.getInstance(application)
 
     val profileState: StateFlow<ProfileState> = userManager.profileState
-
-    private val targetUserCache = LruCache<String, TargetUserFollowData>(3)
 
     private val _benimEngellediklerim = MutableStateFlow<List<String>>(emptyList())
     val benimEngellediklerim: StateFlow<List<String>> = _benimEngellediklerim.asStateFlow()
@@ -29,14 +25,13 @@ class FollowViewModel(application: Application) : AndroidViewModel(application) 
     private val _beniEngelleyenler = MutableStateFlow<List<String>>(emptyList())
     val beniEngelleyenler: StateFlow<List<String>> = _beniEngelleyenler.asStateFlow()
 
-    // Profil Butonlarının State'i
     private val _followUiState = MutableStateFlow(FollowUiState())
     val followUiState: StateFlow<FollowUiState> = _followUiState.asStateFlow()
 
-    private val _targetUserTakipEdilenSayisi = MutableStateFlow<Long>(0L)
+    private val _targetUserTakipEdilenSayisi = MutableStateFlow(0L)
     val targetUserTakipEdilenSayisi: StateFlow<Long> = _targetUserTakipEdilenSayisi.asStateFlow()
 
-    private val _targetUserTakipciSayisi = MutableStateFlow<Long>(0L)
+    private val _targetUserTakipciSayisi = MutableStateFlow(0L)
     val targetUserTakipciSayisi: StateFlow<Long> = _targetUserTakipciSayisi.asStateFlow()
 
     fun profilDurumunuHazirla(targetUserId: String) {
@@ -70,24 +65,12 @@ class FollowViewModel(application: Application) : AndroidViewModel(application) 
     fun takipTakipciSayisiGetir(userId: String, forceRefresh: Boolean = false) {
         val isMyProfile = (userId == userManager.getCurrentUserId())
 
-        if (isMyProfile) {
-            val currentProfile = userManager.profileState.value
-            val hasCachedData = currentProfile.takipciSayisi > 0L || currentProfile.takipEdilenSayisi > 0L
-
-            if (hasCachedData && !forceRefresh) {
-                return
-            }
-        } else {
-            val cachedData = targetUserCache.get(userId)
-            if (cachedData != null && !forceRefresh) {
-                _targetUserTakipciSayisi.value = cachedData.followerCount
-                _targetUserTakipEdilenSayisi.value = cachedData.followingCount
-                return
-            }
-        }
-
         viewModelScope.launch {
-            val result = repository.fetchAndCacheFollowCounts(getApplication<Application>(), userId)
+            val result = repository.fetchAndCacheFollowCounts(
+                userId = userId,
+                isMyProfile = isMyProfile,
+                forceRefresh = forceRefresh
+            )
 
             result.onSuccess { counts ->
                 if (isMyProfile) {
@@ -98,17 +81,9 @@ class FollowViewModel(application: Application) : AndroidViewModel(application) 
                 } else {
                     _targetUserTakipciSayisi.value = counts.followerCount
                     _targetUserTakipEdilenSayisi.value = counts.followingCount
-
-                    targetUserCache.put(
-                        userId,
-                        TargetUserFollowData(
-                            followerCount = counts.followerCount,
-                            followingCount = counts.followingCount
-                        )
-                    )
                 }
             }.onFailure {
-                if (!isMyProfile && targetUserCache.get(userId) == null) {
+                if (!isMyProfile) {
                     _targetUserTakipciSayisi.value = 0L
                     _targetUserTakipEdilenSayisi.value = 0L
                 }
@@ -117,7 +92,7 @@ class FollowViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     fun targetUserClearOrPrepare(targetUserId: String) {
-        val cached = targetUserCache.get(targetUserId)
+        val cached = repository.getCachedTargetUserData(targetUserId)
         if (cached != null) {
             _targetUserTakipciSayisi.value = cached.followerCount
             _targetUserTakipEdilenSayisi.value = cached.followingCount
@@ -127,9 +102,7 @@ class FollowViewModel(application: Application) : AndroidViewModel(application) 
         }
     }
 
-    // Takip Et (Optimistic UI destekli)
     fun takipEt(takipEttiginId: String, currentUserId: String) {
-        // Anında UI güncellemesi (Buton saniyesinde 'Takip Ediliyor'a geçer)
         _followUiState.update { it.copy(isFollowing = true) }
 
         viewModelScope.launch {
@@ -147,24 +120,17 @@ class FollowViewModel(application: Application) : AndroidViewModel(application) 
                     takipEdilenSayisi = currentProfile.takipEdilenSayisi + 1
                 )
 
-                val targetCache = targetUserCache.get(takipEttiginId)
-                val newFollowerCount = (targetCache?.followerCount ?: _targetUserTakipciSayisi.value) + 1
-                val newFollowingCount = targetCache?.followingCount ?: _targetUserTakipEdilenSayisi.value
-
-                val updatedData = TargetUserFollowData(newFollowerCount, newFollowingCount)
-                targetUserCache.put(takipEttiginId, updatedData)
-
-                _targetUserTakipciSayisi.value = newFollowerCount
+                // Güncellenmiş sayıyı Repository önbelleğinden alıp UI'a yansıt
+                repository.getCachedTargetUserData(takipEttiginId)?.let { cachedData ->
+                    _targetUserTakipciSayisi.value = cachedData.followerCount
+                }
             }.onFailure {
-                // Hata durumunda butonu eski haline (false) geri çek
                 _followUiState.update { it.copy(isFollowing = false) }
             }
         }
     }
 
-    // Takipten Çıkar (Optimistic UI destekli)
     fun takiptenCikar(takiptenCiktiginId: String, currentUserId: String) {
-        // Anında UI güncellemesi (Buton saniyesinde 'Takip Et'e geçer)
         _followUiState.update { it.copy(isFollowing = false) }
 
         viewModelScope.launch {
@@ -182,15 +148,11 @@ class FollowViewModel(application: Application) : AndroidViewModel(application) 
                     takipEdilenSayisi = yeniTakipEdilen
                 )
 
-                val targetCache = targetUserCache.get(takiptenCiktiginId)
-                val currentCount = targetCache?.followerCount ?: _targetUserTakipciSayisi.value
-                val newCount = if (currentCount > 0) currentCount - 1 else 0L
-                val newFollowingCount = targetCache?.followingCount ?: _targetUserTakipEdilenSayisi.value
-
-                targetUserCache.put(takiptenCiktiginId, TargetUserFollowData(newCount, newFollowingCount))
-                _targetUserTakipciSayisi.value = newCount
+                // Güncellenmiş sayıyı Repository önbelleğinden alıp UI'a yansıt
+                repository.getCachedTargetUserData(takiptenCiktiginId)?.let { cachedData ->
+                    _targetUserTakipciSayisi.value = cachedData.followerCount
+                }
             }.onFailure {
-                // Hata durumunda butonu eski haline (true) geri çek
                 _followUiState.update { it.copy(isFollowing = true) }
             }
         }
@@ -212,6 +174,27 @@ class FollowViewModel(application: Application) : AndroidViewModel(application) 
                     takipEdilenSayisi = currentProfile.takipEdilenSayisi
                 )
             }
+        }
+    }
+    // FollowViewModel.kt içerisine eklenecek metot:
+    fun setupFromFullProfile(
+        followerCount: Long,
+        followingCount: Long,
+        isSelf: Boolean
+    ) {
+        _followUiState.update { it.copy(isSelfProfile = isSelf) }
+
+        if (isSelf) {
+            // Kendi profilimizse sayıları CurrentUserManager zaten yönetiyor/senkronize ediyor
+            userManager.updateFollowCounts(
+                takipciSayisi = followerCount,
+                takipEdilenSayisi = followingCount
+            )
+        } else {
+            // Başka kullanıcı ise ViewModel state'lerini güncelliyoruz
+            _targetUserTakipciSayisi.value = followerCount
+            _targetUserTakipEdilenSayisi.value = followingCount
+
         }
     }
 }

--- a/app/src/main/java/com/beem/catmap/gonderi/GetProfileFullDataUseCase.kt
+++ b/app/src/main/java/com/beem/catmap/gonderi/GetProfileFullDataUseCase.kt
@@ -1,0 +1,87 @@
+package com.beem.catmap.domain.usecase
+
+import com.beem.catmap.data.local.UserSession
+import com.beem.catmap.data.model.FullProfileData
+import com.beem.catmap.data.repository.FollowCounts
+import com.beem.catmap.data.repository.FollowRepository
+import com.beem.catmap.data.repository.PostRepository
+import com.beem.catmap.gonderi.ProfilePostCacheData
+import com.beem.catmap.gonderi.ProfileRepository
+import com.beem.catmap.gonderi.UiState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+
+class GetProfileFullDataUseCase(
+    private val profileRepository: ProfileRepository,
+    private val postRepository: PostRepository,
+    private val followRepository: FollowRepository
+) {
+    suspend operator fun invoke(
+        targetUserId: String,
+        forceRefresh: Boolean = false
+    ): Result<FullProfileData> = withContext(Dispatchers.IO) {
+        if (targetUserId.isBlank()) {
+            return@withContext Result.failure(Exception("Geçersiz Kullanıcı ID"))
+        }
+
+        try {
+            val isSelf = (targetUserId == UserSession.userId)
+
+            val result: Result<FullProfileData> = coroutineScope {
+                // 1. Profil Bilgilerini Async Çek
+                val profileDeferred = async {
+                    profileRepository.getUserProfile(targetUserId, forceRefresh)
+                }
+
+                // 2. Post Bilgilerini Async Çek
+                val postsDeferred = async {
+                    postRepository.getUserPosts(targetUserId, forceRefresh)
+                }
+
+                // 3. Takip/Takipçi Sayılarını Async Çek
+                val followCountsDeferred = async {
+                    followRepository.fetchAndCacheFollowCounts(
+                        userId = targetUserId,
+                        isMyProfile = isSelf,
+                        forceRefresh = forceRefresh
+                    )
+                }
+
+                // Tüm async işlemlerin tamamlanmasını bekle
+                val profileState = profileDeferred.await()
+                val postsResult = postsDeferred.await()
+                val followCountsResult = followCountsDeferred.await()
+
+                // Profil Verisini Doğrula
+                val profileData = (profileState as? UiState.Success)?.data
+                    ?: return@coroutineScope Result.failure(
+                        Exception((profileState as? UiState.Error)?.message ?: "Profil yüklenemedi.")
+                    )
+
+                // Post Verisini Doğrula (Ağ hatası alsa bile boş liste ile devam etsin, ekran çökmesin)
+                val postsCache = postsResult.getOrElse {
+                    ProfilePostCacheData(emptyList(), emptyList(), 0, true)
+                }
+
+                // Takip Sayılarını Doğrula
+                val followCounts = followCountsResult.getOrDefault(FollowCounts(0L, 0L))
+
+                Result.success(
+                    FullProfileData(
+                        profile = profileData,
+                        postsCache = postsCache,
+                        followerCount = followCounts.followerCount,
+                        followingCount = followCounts.followingCount,
+                        isSelfProfile = isSelf,
+                    )
+                )
+            }
+
+            result
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}

--- a/app/src/main/java/com/beem/catmap/gonderi/GetProfileFullDataUseCase.kt
+++ b/app/src/main/java/com/beem/catmap/gonderi/GetProfileFullDataUseCase.kt
@@ -12,11 +12,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
-
 class GetProfileFullDataUseCase(
     private val profileRepository: ProfileRepository,
-    private val postRepository: PostRepository,
-    private val followRepository: FollowRepository
+    private val postRepository: PostRepository
 ) {
     suspend operator fun invoke(
         targetUserId: String,
@@ -29,57 +27,38 @@ class GetProfileFullDataUseCase(
         try {
             val isSelf = (targetUserId == UserSession.userId)
 
-            val result: Result<FullProfileData> = coroutineScope {
-                // 1. Profil Bilgilerini Async Çek
+            coroutineScope {
                 val profileDeferred = async {
                     profileRepository.getUserProfile(targetUserId, forceRefresh)
                 }
 
-                // 2. Post Bilgilerini Async Çek
                 val postsDeferred = async {
                     postRepository.getUserPosts(targetUserId, forceRefresh)
                 }
 
-                // 3. Takip/Takipçi Sayılarını Async Çek
-                val followCountsDeferred = async {
-                    followRepository.fetchAndCacheFollowCounts(
-                        userId = targetUserId,
-                        isMyProfile = isSelf,
-                        forceRefresh = forceRefresh
-                    )
-                }
-
-                // Tüm async işlemlerin tamamlanmasını bekle
                 val profileState = profileDeferred.await()
                 val postsResult = postsDeferred.await()
-                val followCountsResult = followCountsDeferred.await()
 
-                // Profil Verisini Doğrula
                 val profileData = (profileState as? UiState.Success)?.data
                     ?: return@coroutineScope Result.failure(
                         Exception((profileState as? UiState.Error)?.message ?: "Profil yüklenemedi.")
                     )
 
-                // Post Verisini Doğrula (Ağ hatası alsa bile boş liste ile devam etsin, ekran çökmesin)
                 val postsCache = postsResult.getOrElse {
                     ProfilePostCacheData(emptyList(), emptyList(), 0, true)
                 }
-
-                // Takip Sayılarını Doğrula
-                val followCounts = followCountsResult.getOrDefault(FollowCounts(0L, 0L))
 
                 Result.success(
                     FullProfileData(
                         profile = profileData,
                         postsCache = postsCache,
-                        followerCount = followCounts.followerCount,
-                        followingCount = followCounts.followingCount,
-                        isSelfProfile = isSelf,
+                        followerCount = profileData.takipciSayisi,
+                        followingCount = profileData.takipEdilenSayisi,
+                        postCount = profileData.gonderiSayisi,
+                        isSelfProfile = isSelf
                     )
                 )
             }
-
-            result
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/app/src/main/java/com/beem/catmap/gonderi/PostViewModel.kt
+++ b/app/src/main/java/com/beem/catmap/gonderi/PostViewModel.kt
@@ -26,8 +26,7 @@ import kotlinx.coroutines.launch
 
 class PostViewModel(application: Application) : AndroidViewModel(application) {
 
-    private val repository: PostRepository = PostRepository
-    private val userManager = CurrentUserManager.getInstance(application)
+    private val repository: PostRepository = PostRepository(application)
 
     private val _uiState = MutableStateFlow(ProfilePostUiState())
     val uiState: StateFlow<ProfilePostUiState> = _uiState.asStateFlow()
@@ -54,10 +53,10 @@ class PostViewModel(application: Application) : AndroidViewModel(application) {
                 when (event) {
                     is ProfileEvent.PostAdded -> {
                         Log.d("POST_FLOW_DEBUG", "PostViewModel: PostAdd isteği yakalandı. gonderileriGetir çağrılıyor...")
-                        gonderileriGetir(UserSession.userId, forceRefresh = false)
+                        gonderileriGetir(UserSession.userId, forceRefresh = true)
                     }
                     is ProfileEvent.PostDeleted -> {
-                        gonderileriGetir(UserSession.userId, forceRefresh = false)
+                        gonderileriGetir(UserSession.userId, forceRefresh = true)
                     }
                     else -> {}
                 }
@@ -69,38 +68,6 @@ class PostViewModel(application: Application) : AndroidViewModel(application) {
         _yukleyenID.value = id
     }
 
-    fun profilDurumunuHazirla(targetUserId: String) {
-        setYukleyenID(targetUserId)
-        val isSelf = (targetUserId == UserSession.userId)
-
-        // Veriyi ViewModel önbelleği yerine tek kaynak olan Repository'den istiyoruz
-        val cached = repository.getCachedProfileData(targetUserId)
-        if (cached != null) {
-            Log.d("CACHED", "Cache dolu geldi: ${cached.idList.size}")
-            _uiState.update {
-                it.copy(
-                    posts = cached.posts,
-                    postCount = cached.idList.size,
-                    isEmpty = cached.posts.isEmpty(),
-                    isLoading = false,
-                    isAccessDenied = false
-                )
-            }
-            if (isSelf) {
-                userManager.updateGonderiSayisi(cached.idList.size.toLong())
-            }
-        } else {
-            _uiState.update {
-                it.copy(
-                    posts = emptyList(),
-                    postCount = 0,
-                    isEmpty = true,
-                    isLoading = false,
-                    isAccessDenied = false
-                )
-            }
-        }
-    }
 
     fun gonderileriGetir(userId: String, isFollowing: Boolean = true, forceRefresh: Boolean = false) {
         if (userId.isBlank()) return
@@ -111,14 +78,9 @@ class PostViewModel(application: Application) : AndroidViewModel(application) {
 
             repository.getUserPosts(userId, forceRefresh)
                 .onSuccess { cacheData ->
-                    if (userId == UserSession.userId) {
-                        userManager.updateGonderiSayisi(cacheData.idList.size.toLong())
-                    }
-
                     _uiState.update {
                         it.copy(
                             posts = cacheData.posts,
-                            postCount = cacheData.idList.size,
                             isEmpty = cacheData.posts.isEmpty(),
                             isLoading = false,
                             isAccessDenied = false
@@ -145,7 +107,11 @@ class PostViewModel(application: Application) : AndroidViewModel(application) {
             repository.dahaFazlaGonderiGetir(userId)
                 .onSuccess { cacheData ->
                     _uiState.update {
-                        it.copy(posts = cacheData.posts, isMoreLoading = false)
+                        it.copy(
+                            posts = cacheData.posts,
+                            isEmpty = cacheData.posts.isEmpty(),
+                            isMoreLoading = false
+                        )
                     }
                     isLoadingMore = false
                 }
@@ -203,23 +169,17 @@ class PostViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
-    // PostViewModel.kt içerisine eklenecek metot:
     fun setupFromFullProfile(userId: String, cacheData: ProfilePostCacheData) {
         setYukleyenID(userId)
 
-        // UseCase'den hazır gelen post verisini UI State'e aktar
         _uiState.update {
             it.copy(
                 posts = cacheData.posts,
-                postCount = cacheData.idList.size,
+
                 isEmpty = cacheData.posts.isEmpty(),
                 isLoading = false,
                 isAccessDenied = false
             )
-        }
-
-        if (userId == UserSession.userId) {
-            userManager.updateGonderiSayisi(cacheData.idList.size.toLong())
         }
     }
 }

--- a/app/src/main/java/com/beem/catmap/gonderi/PostViewModel.kt
+++ b/app/src/main/java/com/beem/catmap/gonderi/PostViewModel.kt
@@ -2,14 +2,11 @@ package com.beem.catmap.gonderi
 
 import android.app.Application
 import android.util.Log
-import androidx.collection.LruCache
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.beem.catmap.data.local.UserSession
 import com.beem.catmap.data.repository.PostRepository
 import com.beem.catmap.data.session.CurrentUserManager
-import com.beem.catmap.models.Gonderi
-import com.beem.catmap.models.GonderilenKediItem
 import com.beem.catmap.ui.manager.CatEventBus
 import com.beem.catmap.ui.manager.CatMapEvent
 import com.beem.catmap.ui.manager.ProfileEvent
@@ -38,16 +35,13 @@ class PostViewModel(application: Application) : AndroidViewModel(application) {
     private val _haritaSilindiEvent = MutableSharedFlow<Boolean>(replay = 0)
     val haritaSilindiEvent: SharedFlow<Boolean> = _haritaSilindiEvent.asSharedFlow()
 
-    private val _yukleyenID = MutableStateFlow<String>("")
+    private val _yukleyenID = MutableStateFlow("")
     val yukleyenID: StateFlow<String> = _yukleyenID.asStateFlow()
 
-    private val profileCache = LruCache<String, ProfilePostCacheData>(3)
-
-    private val PAGE_SIZE = 10
     var isLoadingMore = false
 
     val isLastPage: Boolean
-        get() = profileCache.get(_yukleyenID.value)?.isLastPage ?: false
+        get() = repository.isLastPage(_yukleyenID.value)
 
     init {
         observeProfileEvents()
@@ -59,7 +53,7 @@ class PostViewModel(application: Application) : AndroidViewModel(application) {
                 Log.d("POST_FLOW_DEBUG", "PostViewModel: Eventbus'tan Dinlendi -> $event")
                 when (event) {
                     is ProfileEvent.PostAdded -> {
-                        Log.d("POST_FLOW_DEBUG", "PostViewModel: PostAdd isteği yakalandı. gonderiKaydet() çağrılıyor...")
+                        Log.d("POST_FLOW_DEBUG", "PostViewModel: PostAdd isteği yakalandı. gonderileriGetir çağrılıyor...")
                         gonderileriGetir(UserSession.userId, forceRefresh = false)
                     }
                     is ProfileEvent.PostDeleted -> {
@@ -79,7 +73,8 @@ class PostViewModel(application: Application) : AndroidViewModel(application) {
         setYukleyenID(targetUserId)
         val isSelf = (targetUserId == UserSession.userId)
 
-        val cached = profileCache.get(targetUserId)
+        // Veriyi ViewModel önbelleği yerine tek kaynak olan Repository'den istiyoruz
+        val cached = repository.getCachedProfileData(targetUserId)
         if (cached != null) {
             Log.d("CACHED", "Cache dolu geldi: ${cached.idList.size}")
             _uiState.update {
@@ -179,7 +174,6 @@ class PostViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
-
     fun haritadanVeGonderilerdenSil(userId: String, kediId: String) {
         if (kediId.isBlank()) return
         viewModelScope.launch {
@@ -209,4 +203,23 @@ class PostViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    // PostViewModel.kt içerisine eklenecek metot:
+    fun setupFromFullProfile(userId: String, cacheData: ProfilePostCacheData) {
+        setYukleyenID(userId)
+
+        // UseCase'den hazır gelen post verisini UI State'e aktar
+        _uiState.update {
+            it.copy(
+                posts = cacheData.posts,
+                postCount = cacheData.idList.size,
+                isEmpty = cacheData.posts.isEmpty(),
+                isLoading = false,
+                isAccessDenied = false
+            )
+        }
+
+        if (userId == UserSession.userId) {
+            userManager.updateGonderiSayisi(cacheData.idList.size.toLong())
+        }
+    }
 }

--- a/app/src/main/java/com/beem/catmap/gonderi/ProfilFragment.kt
+++ b/app/src/main/java/com/beem/catmap/gonderi/ProfilFragment.kt
@@ -348,7 +348,6 @@ class ProfilFragment : Fragment() {
                 // 5. Post RecyclerView ve UI State Dinleyici
                 launch {
                     viewModel.uiState.collect { state ->
-                        gonderiSayisiTextView.text = state.postCount.toString()
 
                         if (state.isLoading && !swipeRefreshLayout.isRefreshing && gonderiAdapter.itemCount == 0 && shimmerLayout.visibility != View.VISIBLE) {
                             progressBar.visibility = View.VISIBLE
@@ -371,9 +370,7 @@ class ProfilFragment : Fragment() {
                             } else {
                                 tvEmpty.visibility = View.GONE
                                 recyclerView.visibility = View.VISIBLE
-                                gonderiAdapter.submitList(state.posts) {
-                                    recyclerView.scrollToPosition(0)
-                                }
+                                gonderiAdapter.submitList(state.posts)
                             }
                         }
                     }
@@ -386,6 +383,8 @@ class ProfilFragment : Fragment() {
         KullaniciAdi.text = profileData.kullaniciAdi
         tvAd.text = profileData.ad
         bioTextView.text = profileData.hakkinda
+
+        gonderiSayisiTextView.text = profileData.gonderiSayisi.toString()
 
         Glide.with(requireContext())
             .load(profileData.fotoUrl)

--- a/app/src/main/java/com/beem/catmap/gonderi/ProfilFragment.kt
+++ b/app/src/main/java/com/beem/catmap/gonderi/ProfilFragment.kt
@@ -10,7 +10,7 @@ import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.ProgressBar
 import android.widget.TextView
-import android.widget.Toast
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -47,7 +47,9 @@ class ProfilFragment : Fragment() {
     private val followViewModel: FollowViewModel by viewModels()
     private val profileViewModel: ProfileViewModel by viewModels()
     private var postsLoaded = false
-
+    private lateinit var blockedUserLayout: View
+    private lateinit var btnBackEngel: ImageButton
+    private lateinit var KullaniciAdiEngel: TextView
     private lateinit var shimmerLayout: ShimmerFrameLayout
     private lateinit var recyclerView: RecyclerView
     private lateinit var progressBar: ProgressBar
@@ -71,6 +73,7 @@ class ProfilFragment : Fragment() {
     private lateinit var tvAd: TextView
     private lateinit var profilFotoImageView: CircleImageView
     private lateinit var gonderiAdapter: GonderiAdapter
+
     val myUserId = UserSession.userId
     private var targetUserId: String? = null
 
@@ -93,6 +96,20 @@ class ProfilFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         handleBackPressWithEngine()
 
+        initViews(view)
+        showShimmerLoading()
+
+        setupRecyclerView()
+        setupListeners()
+        observeViewModel()
+
+        targetUserId?.let { userId ->
+            followViewModel.profilDurumunuHazirla(userId)///kenı prfılım, takıp takıpcı mı durumalrına bakıyoe
+            profileViewModel.tumProfilVerileriniYukle(userId, forceRefresh = false)
+        }
+    }
+
+    private fun initViews(view: View) {
         shimmerLayout = view.findViewById(R.id.shimmerLayout)
         recyclerView = view.findViewById(R.id.gonderiRecyclerView)
         progressBar = view.findViewById(R.id.progressBarr)
@@ -115,22 +132,25 @@ class ProfilFragment : Fragment() {
         tvAd = view.findViewById(R.id.tvAdSoyad)
         profilFotoImageView = view.findViewById(R.id.profilFotoImageView)
         postSectionHeader = view.findViewById(R.id.postSectionHeader)
+        blockedUserLayout = view.findViewById(R.id.blockedUserLayout)
+        btnBackEngel = view.findViewById(R.id.btnBackEngel)
+        KullaniciAdiEngel = view.findViewById(R.id.KullaniciAdiEngel)
+    }
 
-        shimmerLayout.startShimmer()
-        shimmerLayout.visibility = View.VISIBLE
-        swipeRefreshLayout.visibility = View.GONE
+    // --- UI GÖRÜNÜRLÜK VE SHIMMER METODLARI ---
 
-        setupRecyclerView()
-        setupListeners()
-        observeViewModel()
-
-        targetUserId?.let { userId ->
-            viewModel.profilDurumunuHazirla(userId)
-            followViewModel.profilDurumunuHazirla(userId)
-            followViewModel.targetUserClearOrPrepare(userId)
-            profileViewModel.profilBilgileriniYukle(userId)
-            followViewModel.takipTakipciSayisiGetir(userId, forceRefresh = false)
+    private fun showShimmerLoading() {
+        if (!swipeRefreshLayout.isRefreshing) {
+            shimmerLayout.startShimmer()
+            shimmerLayout.visibility = View.VISIBLE
+            swipeRefreshLayout.visibility = View.GONE
         }
+    }
+
+    private fun hideShimmerLoading() {
+        shimmerLayout.stopShimmer()
+        shimmerLayout.visibility = View.GONE
+        swipeRefreshLayout.visibility = View.VISIBLE
     }
 
     private fun setupRecyclerView() {
@@ -185,6 +205,7 @@ class ProfilFragment : Fragment() {
                 }
             }
         }
+
         takipciSayisiLayout.setOnClickListener {
             targetUserId?.let { userId ->
                 val args = bundleOf(
@@ -195,6 +216,7 @@ class ProfilFragment : Fragment() {
                 SmartNavigationEngine.navigateTo(Screen.FOLLOWERS, args, userId)
             }
         }
+
         takipEdilenSayisiLayout.setOnClickListener {
             targetUserId?.let { userId ->
                 val args = bundleOf(
@@ -224,18 +246,11 @@ class ProfilFragment : Fragment() {
         }
     }
 
+
     private fun yukleVerileri(forceRefresh: Boolean = false) {
         targetUserId?.let { userId ->
-            val currentState = followViewModel.followUiState.value
-            val canLoadPosts = currentState.isFollowing || currentState.isSelfProfile
-
-            followViewModel.takipTakipciSayisiGetir(userId, forceRefresh = forceRefresh)
-
-            viewModel.gonderileriGetir(
-                userId = userId,
-                isFollowing = canLoadPosts,
-                forceRefresh = forceRefresh
-            )
+            followViewModel.profilDurumunuHazirla(userId)///
+            profileViewModel.tumProfilVerileriniYukle(userId, forceRefresh = forceRefresh)
         } ?: run {
             swipeRefreshLayout.isRefreshing = false
         }
@@ -245,6 +260,48 @@ class ProfilFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
 
+                // 1. Ana Profil Verisi Akışı (Single Source of Truth)
+                launch {
+                    profileViewModel.fullProfileState.collect { state ->
+                        when (state) {
+                            is UiState.Loading -> {
+                                showShimmerLoading()
+                            }
+                            is UiState.Success -> {
+                                hideShimmerLoading()
+                                val fullData = state.data
+                                val targetId = targetUserId ?: UserSession.userId ?: ""
+
+                                // PostViewModel'in Paging yapısını verilerle doldur
+                                viewModel.setupFromFullProfile(
+                                    userId = targetId,
+                                    cacheData = fullData.postsCache
+                                )
+
+                                // FollowViewModel'i hazır verilerle doldur
+                                followViewModel.setupFromFullProfile(
+                                    followerCount = fullData.followerCount,
+                                    followingCount = fullData.followingCount,
+                                    isSelf = fullData.isSelfProfile
+                                )
+
+                                // Header profil bilgilerini bağla
+                                bindUserProfileData(fullData.profile)
+                            }
+                            is UiState.Blocked -> {
+                                hideShimmerLoading()
+                                handleBlockedUiState()
+                            }
+                            is UiState.Error -> {
+                                hideShimmerLoading()
+                                swipeRefreshLayout.isRefreshing = false
+                            }
+                            else -> {}
+                        }
+                    }
+                }
+
+                // 2. Profil Güncelleme EventBus Takibi
                 launch {
                     ProfileEventBus.profileEvent.collect { event ->
                         when (event) {
@@ -259,31 +316,14 @@ class ProfilFragment : Fragment() {
                     }
                 }
 
+                // 3. Takip Et / Takipten Çık Buton Durumu Dinleyici
                 launch {
                     followViewModel.followUiState.collectLatest { state ->
                         renderProfileButtons(state)
-
-                        targetUserId?.let { userId ->
-                            val canLoadPosts = state.isFollowing || state.isSelfProfile
-
-                            if (!postsLoaded) {
-                                viewModel.gonderileriGetir(
-                                    userId = userId,
-                                    isFollowing = canLoadPosts,
-                                    forceRefresh = false
-                                )
-                                postsLoaded = true
-                            } else {
-                                viewModel.gonderileriGetir(
-                                    userId = userId,
-                                    isFollowing = canLoadPosts,
-                                    forceRefresh = false
-                                )
-                            }
-                        }
                     }
                 }
 
+                // 4. Takipçi / Takip Edilen Sayıları Dinleyici
                 launch {
                     if (targetUserId == myUserId) {
                         followViewModel.profileState.collect { profileState ->
@@ -305,41 +345,7 @@ class ProfilFragment : Fragment() {
                     }
                 }
 
-                launch {
-                    profileViewModel.userProfile.collect { state ->
-                        when (state) {
-                            is UiState.Loading -> {
-                                if (!swipeRefreshLayout.isRefreshing) {
-                                    shimmerLayout.startShimmer()
-                                    shimmerLayout.visibility = View.VISIBLE
-                                    swipeRefreshLayout.visibility = View.GONE
-                                }
-                            }
-                            is UiState.Success -> {
-                                shimmerLayout.stopShimmer()
-                                shimmerLayout.visibility = View.GONE
-                                swipeRefreshLayout.visibility = View.VISIBLE
-
-                                KullaniciAdi.text = state.data.kullaniciAdi
-                                tvAd.text = state.data.ad
-                                bioTextView.text = state.data.hakkinda
-
-                                Glide.with(requireContext())
-                                    .load(state.data.fotoUrl)
-                                    .placeholder(R.drawable.kullanici)
-                                    .error(R.drawable.kullanici)
-                                    .into(profilFotoImageView)
-                            }
-                            is UiState.Error -> {
-                                shimmerLayout.stopShimmer()
-                                shimmerLayout.visibility = View.GONE
-                                swipeRefreshLayout.visibility = View.VISIBLE
-                            }
-                            else -> {}
-                        }
-                    }
-                }
-
+                // 5. Post RecyclerView ve UI State Dinleyici
                 launch {
                     viewModel.uiState.collect { state ->
                         gonderiSayisiTextView.text = state.postCount.toString()
@@ -374,6 +380,22 @@ class ProfilFragment : Fragment() {
                 }
             }
         }
+    }
+
+    private fun bindUserProfileData(profileData: com.beem.catmap.gonderi.UserProfileData) {
+        KullaniciAdi.text = profileData.kullaniciAdi
+        tvAd.text = profileData.ad
+        bioTextView.text = profileData.hakkinda
+
+        Glide.with(requireContext())
+            .load(profileData.fotoUrl)
+            .placeholder(R.drawable.kullanici)
+            .error(R.drawable.kullanici)
+            .into(profilFotoImageView)
+    }
+
+    private fun handleBlockedUiState() {
+        blockedUserLayout.visibility= View.VISIBLE
     }
 
     private fun renderProfileButtons(state: FollowUiState) {

--- a/app/src/main/java/com/beem/catmap/gonderi/ProfileRepo.kt
+++ b/app/src/main/java/com/beem/catmap/gonderi/ProfileRepo.kt
@@ -40,7 +40,7 @@ class ProfileRepository(private val context: Context) {
         // 1. Kendi profilimiz ise ve yenileme istenmiyorsa CurrentUserManager'dan al
         if (isMyProfile && !forceRefresh) {
             val cachedUser = userManager.getCurrentUser()
-            val cachedBiyografi = userManager.profileState.value.biyografi ?: ""
+            val profileState = userManager.profileState.value
 
             val localProfile = UserProfileData(
                 userId = userId,
@@ -48,7 +48,10 @@ class ProfileRepository(private val context: Context) {
                 ad = cachedUser.getAd() ?: "",
                 soyad = cachedUser.getSoyad(),
                 fotoUrl = cachedUser.getFotoUrl(),
-                hakkinda = cachedBiyografi
+                hakkinda = profileState.biyografi ?: "",
+                takipciSayisi = profileState.takipciSayisi,
+                takipEdilenSayisi = profileState.takipEdilenSayisi,
+                gonderiSayisi = profileState.gonderiSayisi
             )
 
             if (localProfile.kullaniciAdi.isNotBlank()) {
@@ -64,7 +67,7 @@ class ProfileRepository(private val context: Context) {
             }
         }
 
-        // 3. Önbellekte yoksa Firestore'dan çek ve önbellekle
+        // 3. Firestore'dan TEK SEFERDE çek ve önbellekle
         return fetchAndCacheFromFirestore(userId, isMyProfile)
     }
 
@@ -82,23 +85,34 @@ class ProfileRepository(private val context: Context) {
                 val fotoUrl = snapshot.getString("profilFotoUrl")
                 val hakkinda = snapshot.getString("Hakkinda") ?: ""
 
+                // Sayıları TEK BİR belgeden alıyoruz
+                val takipci = snapshot.getLong("takipciSayisi") ?: 0L
+                val takipEdilen = snapshot.getLong("TakipEdilenSayisi") ?: 0L
+                val gonderi = snapshot.getLong("gonderiSayisi") ?: 0L
+
                 val profileData = UserProfileData(
                     userId = userId,
                     kullaniciAdi = kullaniciAdi,
                     ad = ad,
                     soyad = soyad,
                     fotoUrl = fotoUrl,
-                    hakkinda = hakkinda
+                    hakkinda = hakkinda,
+                    takipciSayisi = takipci,
+                    takipEdilenSayisi = takipEdilen,
+                    gonderiSayisi = gonderi
                 )
 
                 // Önbellek güncellemeleri
                 if (isMyProfile) {
-                    updateLocalUserManager(
-                        kullaniciAdi = kullaniciAdi,
+                    userManager.updateProfileDetails(
                         ad = ad,
                         soyad = soyad,
-                        fotoUrl = fotoUrl,
-                        hakkinda = hakkinda
+                        kullaniciAdi = kullaniciAdi,
+                        takipci = takipci,
+                        takipEdilen = takipEdilen,
+                        gonderiSayisi = gonderi,
+                        biyografi = hakkinda,
+                        fotoUrl = fotoUrl
                     )
                 } else {
                     otherUserProfileCache.put(userId, profileData)

--- a/app/src/main/java/com/beem/catmap/gonderi/ProfileRepo.kt
+++ b/app/src/main/java/com/beem/catmap/gonderi/ProfileRepo.kt
@@ -1,37 +1,79 @@
 package com.beem.catmap.gonderi
 
+import android.content.Context
 import android.net.Uri
 import android.util.Log
+import androidx.collection.LruCache
+import com.beem.catmap.KullaniciAuth.Kullanici
+import com.beem.catmap.data.local.UserSession
+import com.beem.catmap.data.session.CurrentUserManager
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.FirebaseFirestoreException
 import com.google.firebase.storage.FirebaseStorage
 import kotlinx.coroutines.tasks.await
 
 sealed class ProfileUpdateResult {
     object Idle : ProfileUpdateResult()
-    data class Success(val newPhotoUrl: String?, val newUsername: String,val newAd: String,val newSoyad: String, val newHakkinda: String) : ProfileUpdateResult()
+    data class Success(
+        val newPhotoUrl: String?,
+        val newUsername: String,
+        val newAd: String,
+        val newSoyad: String,
+        val newHakkinda: String
+    ) : ProfileUpdateResult()
     object UsernameAlreadyTaken : ProfileUpdateResult()
     data class Error(val message: String) : ProfileUpdateResult()
     object Loading : ProfileUpdateResult()
 }
 
-class ProfileRepository {
+class ProfileRepository(private val context: Context) {
 
     private val db = FirebaseFirestore.getInstance()
     private val storage = FirebaseStorage.getInstance()
+    private val userManager = CurrentUserManager.getInstance(context)
 
-    /**
-     * Kullanıcının TÜM profil bilgilerini TEK BİR doküman okumasıyla getirir.
-     */
-    suspend fun getUserProfile(userId: String): UserProfileData? {
+    private val otherUserProfileCache = LruCache<String, UserProfileData>(10)
+
+    suspend fun getUserProfile(userId: String, forceRefresh: Boolean = false): UiState<UserProfileData> {
+        val isMyProfile = userId == UserSession.userId
+
+        // 1. Kendi profilimiz ise ve yenileme istenmiyorsa CurrentUserManager'dan al
+        if (isMyProfile && !forceRefresh) {
+            val cachedUser = userManager.getCurrentUser()
+            val cachedBiyografi = userManager.profileState.value.biyografi ?: ""
+
+            val localProfile = UserProfileData(
+                userId = userId,
+                kullaniciAdi = cachedUser.getKullaniciAdi() ?: "",
+                ad = cachedUser.getAd() ?: "",
+                soyad = cachedUser.getSoyad(),
+                fotoUrl = cachedUser.getFotoUrl(),
+                hakkinda = cachedBiyografi
+            )
+
+            if (localProfile.kullaniciAdi.isNotBlank()) {
+                return UiState.Success(localProfile)
+            }
+        }
+
+        // 2. Başka bir kullanıcının profili ise ve yenileme istenmiyorsa LruCache'den al
+        if (!isMyProfile && !forceRefresh) {
+            val cachedData = otherUserProfileCache.get(userId)
+            if (cachedData != null) {
+                return UiState.Success(cachedData)
+            }
+        }
+
+        // 3. Önbellekte yoksa Firestore'dan çek ve önbellekle
+        return fetchAndCacheFromFirestore(userId, isMyProfile)
+    }
+
+    private suspend fun fetchAndCacheFromFirestore(userId: String, isMyProfile: Boolean): UiState<UserProfileData> {
         return try {
-            Log.d("PROFILE", "İstenen userId = $userId")
-
             val snapshot = db.collection("users")
                 .document(userId)
                 .get()
                 .await()
-
-            Log.d("PROFILE", "exists = ${snapshot.exists()}")
 
             if (snapshot.exists()) {
                 val ad = snapshot.getString("Ad") ?: ""
@@ -40,9 +82,7 @@ class ProfileRepository {
                 val fotoUrl = snapshot.getString("profilFotoUrl")
                 val hakkinda = snapshot.getString("Hakkinda") ?: ""
 
-                Log.d("PROFILE", "Getirilen -> KullaniciAdi: $kullaniciAdi, fotoUrl: $fotoUrl, Hakkinda: $hakkinda")
-
-                UserProfileData(
+                val profileData = UserProfileData(
                     userId = userId,
                     kullaniciAdi = kullaniciAdi,
                     ad = ad,
@@ -50,20 +90,71 @@ class ProfileRepository {
                     fotoUrl = fotoUrl,
                     hakkinda = hakkinda
                 )
+
+                // Önbellek güncellemeleri
+                if (isMyProfile) {
+                    updateLocalUserManager(
+                        kullaniciAdi = kullaniciAdi,
+                        ad = ad,
+                        soyad = soyad,
+                        fotoUrl = fotoUrl,
+                        hakkinda = hakkinda
+                    )
+                } else {
+                    otherUserProfileCache.put(userId, profileData)
+                }
+
+                UiState.Success(profileData)
             } else {
-                Log.d("PROFILE", "Doküman bulunamadı.")
-                null
+                UiState.Error("Kullanıcı bulunamadı.")
+            }
+        } catch (e: FirebaseFirestoreException) {
+            if (e.code == FirebaseFirestoreException.Code.PERMISSION_DENIED) {
+                UiState.Blocked
+            } else {
+                UiState.Error(e.localizedMessage ?: "Veritabanı hatası oluştu.")
             }
         } catch (e: Exception) {
-            Log.e("PROFILE", "getUserProfile hata", e)
-            null
+            UiState.Error(e.localizedMessage ?: "Bilinmeyen bir hata oluştu.")
         }
     }
 
-    /**
-     * Tüm profil değişikliklerini Kontrol Edip Toplu Günceller
-     */
-    suspend fun updateFullProfile(currentUserId: String, currentUsername: String, newUsername: String, currentAd: String, newAd: String,currentSoyad: String,newSoyad: String,newHakkinda: String, newImageUri: Uri?): ProfileUpdateResult {
+    fun updateLokalUserSession(guncelKullanici: Kullanici, eskiProfileData: UserProfileData): UserProfileData {
+        val yeniKullaniciAdi = guncelKullanici.kullaniciAdi?.takeIf { it.isNotBlank() } ?: eskiProfileData.kullaniciAdi
+        val yeniAd = guncelKullanici.ad?.takeIf { it.isNotBlank() } ?: eskiProfileData.ad
+        val yeniSoyad = guncelKullanici.soyad ?: eskiProfileData.soyad
+        val yeniBio = guncelKullanici.biyografi ?: eskiProfileData.hakkinda
+        val yeniFotoUrl = guncelKullanici.fotoUrl?.takeIf { it.isNotBlank() } ?: eskiProfileData.fotoUrl
+
+        updateLocalUserManager(
+            kullaniciAdi = yeniKullaniciAdi,
+            ad = yeniAd,
+            soyad = yeniSoyad,
+            fotoUrl = yeniFotoUrl,
+            hakkinda = yeniBio
+        )
+
+        return UserProfileData(
+            userId = eskiProfileData.userId,
+            kullaniciAdi = yeniKullaniciAdi,
+            ad = yeniAd,
+            soyad = yeniSoyad,
+            fotoUrl = yeniFotoUrl,
+            hakkinda = yeniBio
+        )
+    }
+
+    suspend fun updateFullProfile(
+        currentUserId: String,
+        currentUsername: String,
+        newUsername: String,
+        currentAd: String,
+        newAd: String,
+        currentSoyad: String,
+        newSoyad: String,
+        newHakkinda: String,
+        newImageUri: Uri?
+    ): ProfileUpdateResult {
         return try {
             val updates = mutableMapOf<String, Any>()
             var uploadedPhotoUrl: String? = null
@@ -97,12 +188,26 @@ class ProfileRepository {
                     .await()
             }
 
+            val finalUsername = newUsername.trim()
+            val finalAd = newAd.trim()
+            val finalSoyad = newSoyad.trim()
+            val finalHakkinda = newHakkinda.trim()
+
+            // Yerel cache/UserManager güncellemesini Repository üstlenir
+            updateLocalUserManager(
+                kullaniciAdi = finalUsername,
+                ad = finalAd,
+                soyad = finalSoyad,
+                fotoUrl = uploadedPhotoUrl,
+                hakkinda = finalHakkinda
+            )
+
             ProfileUpdateResult.Success(
                 newPhotoUrl = uploadedPhotoUrl,
-                newUsername = newUsername.trim(),
-                newAd = newAd.trim(),
-                newSoyad = newSoyad.trim(),
-                newHakkinda = newHakkinda.trim()
+                newUsername = finalUsername,
+                newAd = finalAd,
+                newSoyad = finalSoyad,
+                newHakkinda = finalHakkinda
             )
 
         } catch (e: Exception) {
@@ -110,7 +215,23 @@ class ProfileRepository {
             ProfileUpdateResult.Error(e.localizedMessage ?: "Profil güncellenirken bir hata oluştu.")
         }
     }
-    // --- YARDIMCI METOTLAR ---
+
+    private fun updateLocalUserManager(
+        kullaniciAdi: String,
+        ad: String,
+        soyad: String?,
+        fotoUrl: String?,
+        hakkinda: String
+    ) {
+        userManager.updateBiyografi(hakkinda)
+        val currentUser = userManager.getCurrentUser().apply {
+            setKullaniciAdi(kullaniciAdi)
+            setAd(ad)
+            setSoyad(soyad ?: "")
+            fotoUrl?.let { setFotoUrl(it) }
+        }
+        userManager.setCurrentUser(currentUser)
+    }
 
     private suspend fun uploadProfilePhotoToStorage(imageUri: Uri, userId: String): String {
         val ref = storage.reference.child("profile_images/$userId.jpg")
@@ -119,7 +240,6 @@ class ProfileRepository {
     }
 
     private suspend fun checkUsernameAvailability(username: String, currentUserId: String): Boolean {
-        // Firestore'da arama yaparken 'KullaniciAdi' alan adını kullanıyoruz
         val snapshot = db.collection("users")
             .whereEqualTo("KullaniciAdi", username)
             .get()

--- a/app/src/main/java/com/beem/catmap/gonderi/ProfileUiState.kt
+++ b/app/src/main/java/com/beem/catmap/gonderi/ProfileUiState.kt
@@ -1,24 +1,25 @@
 package com.beem.catmap.gonderi
 
-data class ProfileUiState(
-    val isSelfProfile: Boolean = false,       // Kendi profilimiz mi?
-    val isFollowing: Boolean = false,         // Takip ediyor muyuz?
-    val isFollowed: Boolean = false,
-    val isLoadingFollowState: Boolean = false // Takip et butonu yükleniyor mu?
-)
 
 data class ProfileState(
+    val ad: String? = null,
+    val soyad: String? = null,
+    val kullaniciAdi: String? = null,
     val takipciSayisi: Long = 0L,
     val takipEdilenSayisi: Long = 0L,
     val gonderiSayisi: Long = 0L,
-    val biyografi: String = ""
+    val biyografi: String? = null,
+    val fotoUrl: String? = null
 )
 
 data class UserProfileData(
-    val userId: String,
+    val userId: String = "",
     val kullaniciAdi: String = "",
     val ad: String = "",
-    val soyad: String="",
+    val soyad: String? = null,
     val fotoUrl: String? = null,
-    val hakkinda: String = ""
+    val hakkinda: String = "",
+    val takipciSayisi: Long = 0L,
+    val takipEdilenSayisi: Long = 0L,
+    val gonderiSayisi: Long = 0L
 )

--- a/app/src/main/java/com/beem/catmap/gonderi/ProfileViewModel.kt
+++ b/app/src/main/java/com/beem/catmap/gonderi/ProfileViewModel.kt
@@ -17,13 +17,10 @@ import kotlinx.coroutines.launch
 class ProfileViewModel(application: Application) : AndroidViewModel(application) {
 
     private val repository: ProfileRepository = ProfileRepository(application)
-    private val postRepository = PostRepository
-    private val followRepository = FollowRepository(application)
-
+    private val postRepository :PostRepository = PostRepository(application)
     private val getProfileFullDataUseCase = GetProfileFullDataUseCase(
         profileRepository = repository,
         postRepository = postRepository,
-        followRepository = followRepository
     )
 
     // Artık Tek Kaynak (Single Source of Truth) Olarak _fullProfileState Kullanıyoruz
@@ -120,7 +117,7 @@ class ProfileViewModel(application: Application) : AndroidViewModel(application)
                         ad = result.newAd,
                         soyad = result.newSoyad,
                         fotoUrl = result.newPhotoUrl ?: currentProfile.fotoUrl,
-                        hakkinda = result.newHakkinda
+                        hakkinda = result.newHakkinda,
                     )
 
                     _fullProfileState.value = UiState.Success(

--- a/app/src/main/java/com/beem/catmap/gonderi/ProfileViewModel.kt
+++ b/app/src/main/java/com/beem/catmap/gonderi/ProfileViewModel.kt
@@ -2,117 +2,63 @@ package com.beem.catmap.gonderi
 
 import android.app.Application
 import android.net.Uri
-import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.beem.catmap.KullaniciAuth.Kullanici
-import com.beem.catmap.data.local.UserSession
-import com.beem.catmap.data.session.CurrentUserManager
+import com.beem.catmap.data.model.FullProfileData
+import com.beem.catmap.data.repository.FollowRepository
+import com.beem.catmap.data.repository.PostRepository
+import com.beem.catmap.domain.usecase.GetProfileFullDataUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 class ProfileViewModel(application: Application) : AndroidViewModel(application) {
-    private val repository: ProfileRepository = ProfileRepository()
 
-    private val userManager = CurrentUserManager.getInstance(application)
-    val profileState: StateFlow<ProfileState> = userManager.profileState
+    private val repository: ProfileRepository = ProfileRepository(application)
+    private val postRepository = PostRepository
+    private val followRepository = FollowRepository(application)
 
-    private val _userProfile = MutableStateFlow<UiState<UserProfileData>>(UiState.Idle)
-    val userProfile: StateFlow<UiState<UserProfileData>> = _userProfile.asStateFlow()
+    private val getProfileFullDataUseCase = GetProfileFullDataUseCase(
+        profileRepository = repository,
+        postRepository = postRepository,
+        followRepository = followRepository
+    )
+
+    // Artık Tek Kaynak (Single Source of Truth) Olarak _fullProfileState Kullanıyoruz
+    private val _fullProfileState = MutableStateFlow<UiState<FullProfileData>>(UiState.Idle)
+    val fullProfileState: StateFlow<UiState<FullProfileData>> = _fullProfileState.asStateFlow()
 
     private val _profileUpdateState = MutableStateFlow<ProfileUpdateResult>(ProfileUpdateResult.Idle)
     val profileUpdateState: StateFlow<ProfileUpdateResult> = _profileUpdateState.asStateFlow()
 
-    // ProfileViewModel.kt içine eklenecek:
-    fun lokalProfilVerisiniGuncelle(guncelKullanici: Kullanici) {
-        val currentState = _userProfile.value
-        if (currentState is UiState.Success) {
-            val eskiData = currentState.data
-
-            // Kullanici nesnesinden gelen yeni değerleri alıyoruz (Null ise eski veriyi koruyoruz)
-            val yeniKullaniciAdi = guncelKullanici.kullaniciAdi?.takeIf { it.isNotBlank() } ?: eskiData.kullaniciAdi
-            val yeniAd = guncelKullanici.ad?.takeIf { it.isNotBlank() } ?: eskiData.ad
-            val yeniSoyad = guncelKullanici.soyad ?: eskiData.soyad
-            val yeniBio = guncelKullanici.biyografi ?: eskiData.hakkinda
-            val yeniFotoUrl = guncelKullanici.fotoUrl?.takeIf { it.isNotBlank() } ?: eskiData.fotoUrl
-
-            // 1. ViewModel'deki UI State'i doğrudan güncelliyoruz
-            val yeniProfileData = UserProfileData(
-                userId = eskiData.userId,
-                kullaniciAdi = yeniKullaniciAdi,
-                ad = yeniAd,
-                soyad = yeniSoyad,
-                fotoUrl = yeniFotoUrl,
-                hakkinda = yeniBio
-            )
-            _userProfile.value = UiState.Success(yeniProfileData)
-
-            // 2. Local Cache / UserManager nesnelerimizi de senkronize tutuyoruz
-            userManager.updateBiyografi(yeniBio)
-            val currentUser = userManager.getCurrentUser().apply {
-                setKullaniciAdi(yeniKullaniciAdi)
-                setAd(yeniAd)
-                setSoyad(yeniSoyad)
-                yeniFotoUrl?.let { setFotoUrl(it) }
-            }
-            userManager.setCurrentUser(currentUser)
-        }
-    }
-    fun profilBilgileriniYukle(kullaniciId: String) {
+    fun tumProfilVerileriniYukle(targetUserId: String, forceRefresh: Boolean = false) {
         viewModelScope.launch {
-            _userProfile.value = UiState.Loading
-
-            val isMyProfile = kullaniciId == UserSession.userId
-            if (isMyProfile) {
-                val cachedUser = userManager.getCurrentUser()
-                val cachedBiyografi = userManager.profileState.value.biyografi ?: ""
-
-                Log.d("CACHED","ismyprofıle"+ cachedBiyografi)
-                val localProfile = UserProfileData(
-                    userId = kullaniciId,
-                    kullaniciAdi = cachedUser.getKullaniciAdi() ?: "",
-                    ad = cachedUser.getAd() ?:"",
-                    soyad = cachedUser.getSoyad(),
-                    fotoUrl = cachedUser.getFotoUrl(),
-                    hakkinda = cachedBiyografi
-                )
-
-                if (localProfile.kullaniciAdi.isNotBlank()) {
-                    Log.d("CACHED","buraya mı girdi"+localProfile.kullaniciAdi)
-                    _userProfile.value = UiState.Success(localProfile)
-                    return@launch
+            _fullProfileState.value = UiState.Loading
+            getProfileFullDataUseCase(targetUserId, forceRefresh)
+                .onSuccess { fullData ->
+                    _fullProfileState.value = UiState.Success(fullData)
                 }
-            }
-            Log.d("CACHED","yok")
-            fetchAndCacheProfileFromDb(kullaniciId, isMyProfile)
+                .onFailure { exception ->
+                    _fullProfileState.value = UiState.Error(exception.localizedMessage ?: "Profil yüklenemedi.")
+                }
         }
     }
 
-    private suspend fun fetchAndCacheProfileFromDb(kullaniciId: String, isMyProfile: Boolean) {
-        val profileData = repository.getUserProfile(kullaniciId)
+    fun lokalProfilVerisiniGuncelle(guncelKullanici: Kullanici) {
+        val currentState = _fullProfileState.value
+        if (currentState is UiState.Success) {
+            val mevcutFullData = currentState.data
+            val yeniProfileData = repository.updateLokalUserSession(guncelKullanici, mevcutFullData.profile)
 
-        if (profileData != null) {
-            _userProfile.value = UiState.Success(profileData)
-            Log.d("PROFILE_DEBUG", "userId=$kullaniciId")
-            Log.d("PROFILE_DEBUG", "profileData=$profileData")
-
-            if (isMyProfile) {
-                userManager.updateBiyografi(profileData.hakkinda)
-                val currentUser = userManager.getCurrentUser().apply {
-                    setKullaniciAdi(profileData.kullaniciAdi)
-                    setAd(profileData.ad)
-                    setSoyad(profileData.soyad)
-                    profileData.fotoUrl?.let { setFotoUrl(it) }
-                }
-                userManager.setCurrentUser(currentUser)
-            }
-        } else {
-            Log.d("PROFILE_DEBUG", "profileData NULL")
-            _userProfile.value = UiState.Error("Kullanıcı bilgileri alınamadı.")
+            // FullProfileData içerisindeki profile nesnesini güncelleyip State'e yazıyoruz
+            _fullProfileState.value = UiState.Success(
+                mevcutFullData.copy(profile = yeniProfileData)
+            )
         }
     }
+
     fun tumProfilBilgileriniGuncelle(
         yeniKullaniciAdi: String,
         yeniAd: String,
@@ -121,25 +67,24 @@ class ProfileViewModel(application: Application) : AndroidViewModel(application)
         yeniResimUri: Uri?,
         currentUserId: String
     ) {
-        // 1. Halihazırda güncelleme yapılıyorsa tekrar başlatma
         if (_profileUpdateState.value is ProfileUpdateResult.Loading) return
 
-        // 2. Mevcut profil verilerini al
-        val currentProfile = (_userProfile.value as? UiState.Success)?.data
-        val currentUser = userManager.getCurrentUser()
+        // Mevcut profil verisini _fullProfileState içerisinden alıyoruz
+        val currentFullData = (_fullProfileState.value as? UiState.Success)?.data
+        val currentProfile = currentFullData?.profile
 
-        val currentUsername = currentProfile?.kullaniciAdi ?: currentUser.getKullaniciAdi() ?: ""
-        val currentAd = currentProfile?.ad ?: currentUser.getAd() ?: ""
-        val currentSoyad = currentProfile?.soyad ?: currentUser.getSoyad() ?: ""
-        val currentBio = currentProfile?.hakkinda ?: userManager.profileState.value.biyografi ?: ""
+        val currentUsername = currentProfile?.kullaniciAdi ?: ""
+        val currentAd = currentProfile?.ad ?: ""
+        val currentSoyad = currentProfile?.soyad ?: ""
+        val currentBio = currentProfile?.hakkinda ?: ""
 
-        // 3. Değişiklik kontrolü: Herhangi bir alan değişmiş mi ya da yeni resim seçilmiş mi?
         val isUsernameChanged = yeniKullaniciAdi != currentUsername
         val isAdChanged = yeniAd != currentAd
         val isSoyadChanged = yeniSoyad != currentSoyad
         val isBioChanged = yeniHakkinda != currentBio
         val isImageChanged = yeniResimUri != null
 
+        // Hiçbir değişiklik yoksa işlemi sonlandır
         if (!isUsernameChanged && !isAdChanged && !isSoyadChanged && !isBioChanged && !isImageChanged) {
             _profileUpdateState.value = ProfileUpdateResult.Success(
                 newUsername = currentUsername,
@@ -154,46 +99,39 @@ class ProfileViewModel(application: Application) : AndroidViewModel(application)
         viewModelScope.launch {
             _profileUpdateState.value = ProfileUpdateResult.Loading
 
-            try {
-                val result = repository.updateFullProfile(
-                    currentUserId = currentUserId,
-                    currentUsername = currentUsername,
-                    newUsername = yeniKullaniciAdi,
-                    currentAd = currentAd,
-                    newAd = yeniAd,
-                    currentSoyad = currentSoyad,
-                    newSoyad = yeniSoyad,
-                    newHakkinda = yeniHakkinda,
-                    newImageUri = yeniResimUri
-                )
+            val result = repository.updateFullProfile(
+                currentUserId = currentUserId,
+                currentUsername = currentUsername,
+                newUsername = yeniKullaniciAdi,
+                currentAd = currentAd,
+                newAd = yeniAd,
+                currentSoyad = currentSoyad,
+                newSoyad = yeniSoyad,
+                newHakkinda = yeniHakkinda,
+                newImageUri = yeniResimUri
+            )
 
-                if (result is ProfileUpdateResult.Success) {
-                    currentUser.setKullaniciAdi(result.newUsername)
-                    currentUser.setAd(result.newAd)
-                    currentUser.setSoyad(result.newSoyad)
-                    result.newPhotoUrl?.let { currentUser.setFotoUrl(it) }
+            if (result is ProfileUpdateResult.Success) {
+                // Başarılı güncelleme sonrası mevcut FullProfileData nesnesini güncelliyoruz
+                if (currentFullData != null && currentProfile != null) {
+                    val guncellenmisProfileData = UserProfileData(
+                        userId = currentUserId,
+                        kullaniciAdi = result.newUsername,
+                        ad = result.newAd,
+                        soyad = result.newSoyad,
+                        fotoUrl = result.newPhotoUrl ?: currentProfile.fotoUrl,
+                        hakkinda = result.newHakkinda
+                    )
 
-                    userManager.setCurrentUser(currentUser)
-                    userManager.updateBiyografi(result.newHakkinda)
-
-                    val currentPhoto = (_userProfile.value as? UiState.Success)?.data?.fotoUrl
-                    _userProfile.value = UiState.Success(
-                        UserProfileData(
-                            userId = currentUserId,
-                            kullaniciAdi = result.newUsername,
-                            ad = result.newAd,
-                            soyad = result.newSoyad,
-                            fotoUrl = result.newPhotoUrl ?: currentPhoto,
-                            hakkinda = result.newHakkinda
-                        )
+                    _fullProfileState.value = UiState.Success(
+                        currentFullData.copy(profile = guncellenmisProfileData)
                     )
                 }
-                _profileUpdateState.value = result
-            } catch (e: Exception) {
-                _profileUpdateState.value = ProfileUpdateResult.Error(e.localizedMessage ?: "Bilinmeyen bir hata oluştu.")
             }
+            _profileUpdateState.value = result
         }
     }
+
     fun resetUpdateState() {
         _profileUpdateState.value = ProfileUpdateResult.Idle
     }

--- a/app/src/main/java/com/beem/catmap/gonderi/UiState.kt
+++ b/app/src/main/java/com/beem/catmap/gonderi/UiState.kt
@@ -5,5 +5,5 @@ sealed interface UiState<out T> {
     object Loading : UiState<Nothing>
     data class Success<T>(val data: T) : UiState<T>
     data class Error(val message: String) : UiState<Nothing>
-    object AccessDenied : UiState<Nothing>
+    object Blocked : UiState<Nothing>
 }

--- a/app/src/main/java/com/beem/catmap/gonderi/duzenleme/EditProfileFragment.kt
+++ b/app/src/main/java/com/beem/catmap/gonderi/duzenleme/EditProfileFragment.kt
@@ -12,20 +12,16 @@ import android.widget.ImageButton
 import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.lifecycle.viewModelScope
 import com.beem.catmap.KullaniciAuth.Kullanici
 import com.beem.catmap.R
 import com.beem.catmap.data.local.UserSession
 import com.beem.catmap.gonderi.ProfileUpdateResult
 import com.beem.catmap.gonderi.ProfileViewModel
 import com.beem.catmap.gonderi.UiState
-import com.beem.catmap.ui.manager.CatEventBus
-import com.beem.catmap.ui.manager.CatMapEvent
 import com.beem.catmap.ui.manager.ProfileEvent
 import com.beem.catmap.ui.manager.ProfileEventBus
 import com.beem.catmap.ui.manager.UiMessageManager
@@ -89,10 +85,10 @@ class EditProfileFragment : Fragment() {
         observeViewModel()
 
         if (currentUserId.isNotBlank()) {
-            profileViewModel.profilBilgileriniYukle(currentUserId)
+            // Tek kaynak UseCase üzerinden tüm verileri yüklüyoruz
+            profileViewModel.tumProfilVerileriniYukle(currentUserId, forceRefresh = false)
         }
     }
-
 
     private fun initViews(view: View) {
         btnBack = view.findViewById(R.id.btnBack)
@@ -139,17 +135,21 @@ class EditProfileFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
 
+                // 1. Profil İlk Bilgilerini fullProfileState Üzerinden Dinle
                 launch {
-                    profileViewModel.userProfile.collect { state ->
+                    profileViewModel.fullProfileState.collect { state ->
                         if (state is UiState.Success) {
-                            val data = state.data
+                            val data = state.data.profile
+
+                            // Fotoğraf henüz galeriden seçilmediyse Firestore'daki güncel fotoğrafı bas
                             if (selectedImageUri == null && !data.fotoUrl.isNullOrBlank()) {
                                 Glide.with(this@EditProfileFragment)
                                     .load(data.fotoUrl)
                                     .placeholder(R.drawable.kullanici)
                                     .into(profilFotoImageView)
                             }
-                            // Metinler boşsa doldur
+
+                            // Input alanları henüz doldurulmadıysa değerleri yerleştir
                             if (editKullaniciAdi.text.isNullOrBlank()) {
                                 editKullaniciAdi.setText(data.kullaniciAdi)
                             }
@@ -166,6 +166,7 @@ class EditProfileFragment : Fragment() {
                     }
                 }
 
+                // 2. Profil Güncelleme Durumunu Dinle
                 launch {
                     profileViewModel.profileUpdateState.collect { result ->
                         when (result) {
@@ -177,16 +178,19 @@ class EditProfileFragment : Fragment() {
                                 UiMessageManager.emitMessage(UiMessageState.Success("Profil başarıyla güncellendi."))
                                 profileViewModel.resetUpdateState()
 
+                                // Güncellenmiş profil verisini almak için mevcut state'i okuyoruz
+                                val currentData = (profileViewModel.fullProfileState.value as? UiState.Success)?.data?.profile
+
                                 val guncelKullanici = Kullanici(
                                     currentUserId,
                                     editKullaniciAdi.text?.toString()?.trim().orEmpty(),
                                     editAd.text?.toString()?.trim().orEmpty(),
                                     editSoyad.text?.toString()?.trim().orEmpty(),
                                     editBio.text?.toString()?.trim().orEmpty(),
-                                    selectedImageUri?.toString() ?: (profileViewModel.userProfile.value as? UiState.Success)?.data?.fotoUrl
+                                    currentData?.fotoUrl // Yüklenmiş gerçek sunucu URL'si
                                 )
 
-                                // Event ile fırlatıyoruz
+                                // EventBus ile tüm dinleyicilere fırlatıyoruz
                                 lifecycleScope.launch {
                                     ProfileEventBus.emitEvent(ProfileEvent.ProfileUpdated(guncelKullanici))
                                 }
@@ -214,10 +218,10 @@ class EditProfileFragment : Fragment() {
 
     private fun clearEditState() {
         selectedImageUri = null
-        val currentState = profileViewModel.userProfile.value
-        if (currentState is UiState.Success && !currentState.data.fotoUrl.isNullOrBlank()) {
+        val currentState = profileViewModel.fullProfileState.value
+        if (currentState is UiState.Success && !currentState.data.profile.fotoUrl.isNullOrBlank()) {
             Glide.with(this)
-                .load(currentState.data.fotoUrl)
+                .load(currentState.data.profile.fotoUrl)
                 .placeholder(R.drawable.kullanici)
                 .into(profilFotoImageView)
         } else {

--- a/app/src/main/java/com/beem/catmap/ui/auth/AuthFragment.kt
+++ b/app/src/main/java/com/beem/catmap/ui/auth/AuthFragment.kt
@@ -124,10 +124,16 @@ class AuthFragment : Fragment() {
                 }
 
                 val doc = query.documents[0]
+                user.kullaniciAdi = doc.getString("KullaniciAdi") ?: username // <-- EKLENDİ
                 user.ad = doc.getString("Ad")
                 user.soyad = doc.getString("Soyad")
                 user.email = doc.getString("Email")
-                // Doküman ID'si zaten Auth UID ile aynıdır
+                user.fotoUrl = doc.getString("profilFotoUrl")
+                user.biyografi = doc.getString("Hakkinda")
+                user.takipEdilenSayisi = doc.getLong("TakipEdilenSayisi")
+                user.takipciSayisi = doc.getLong("takipciSayisi")
+                user.gonderiSayisi = doc.getLong("gonderiSayisi") ?: 0L
+
                 user.setID(doc.id)
 
                 val ynt = DogrulamaKodYonetici()

--- a/app/src/main/res/layout/fragment_profil_sayfasi.xml
+++ b/app/src/main/res/layout/fragment_profil_sayfasi.xml
@@ -1,208 +1,209 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/swipeRefreshLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/white">
 
-    <!-- SHIMMER LAYOUT -->
-    <com.facebook.shimmer.ShimmerFrameLayout
-        android:id="@+id/shimmerLayout"
+    <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:padding="16dp"
-        android:visibility="gone"
-        app:shimmer_auto_start="true">
+        android:layout_height="match_parent">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <!-- 1. SHIMMER LAYOUT -->
+        <com.facebook.shimmer.ShimmerFrameLayout
+            android:id="@+id/shimmerLayout"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:padding="16dp"
+            android:visibility="gone"
+            app:shimmer_auto_start="true">
 
-            <!-- Shimmer Üst Bar (Back + Username) -->
-            <View
-                android:id="@+id/shimmerBtnBack"
-                android:layout_width="32dp"
-                android:layout_height="32dp"
-                android:background="@drawable/shimmer_placeholder"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
 
-            <View
-                android:id="@+id/shimmerTopUsername"
-                android:layout_width="120dp"
-                android:layout_height="20dp"
-                android:layout_marginStart="12dp"
-                android:background="@drawable/shimmer_placeholder"
-                app:layout_constraintBottom_toBottomOf="@id/shimmerBtnBack"
-                app:layout_constraintStart_toEndOf="@id/shimmerBtnBack"
-                app:layout_constraintTop_toTopOf="@id/shimmerBtnBack" />
-
-            <!-- Profil Fotoğrafı Placeholder -->
-            <View
-                android:id="@+id/shimmerAvatar"
-                android:layout_width="90dp"
-                android:layout_height="90dp"
-                android:layout_marginTop="24dp"
-                android:background="@drawable/shimmer_placeholder_circle"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/shimmerBtnBack" />
-
-            <!-- Ad Soyad Placeholder (Fotoğrafın Yanındaki) -->
-            <View
-                android:id="@+id/shimmerFullName"
-                android:layout_width="140dp"
-                android:layout_height="20dp"
-                android:layout_marginStart="16dp"
-                android:background="@drawable/shimmer_placeholder"
-                app:layout_constraintStart_toEndOf="@id/shimmerAvatar"
-                app:layout_constraintTop_toTopOf="@id/shimmerAvatar" />
-
-            <!-- Sayılar Placeholder -->
-            <LinearLayout
-                android:id="@+id/shimmerStats"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="16dp"
-                android:layout_marginTop="12dp"
-                android:orientation="horizontal"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/shimmerAvatar"
-                app:layout_constraintTop_toBottomOf="@id/shimmerFullName">
+                <!-- Shimmer Üst Bar (Back + Username) -->
+                <View
+                    android:id="@+id/shimmerBtnBack"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:background="@drawable/shimmer_placeholder"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
                 <View
-                    android:layout_width="0dp"
-                    android:layout_height="32dp"
-                    android:layout_marginHorizontal="4dp"
-                    android:layout_weight="1"
-                    android:background="@drawable/shimmer_placeholder" />
+                    android:id="@+id/shimmerTopUsername"
+                    android:layout_width="120dp"
+                    android:layout_height="20dp"
+                    android:layout_marginStart="12dp"
+                    android:background="@drawable/shimmer_placeholder"
+                    app:layout_constraintBottom_toBottomOf="@id/shimmerBtnBack"
+                    app:layout_constraintStart_toEndOf="@id/shimmerBtnBack"
+                    app:layout_constraintTop_toTopOf="@id/shimmerBtnBack" />
 
+                <!-- Profil Fotoğrafı Placeholder -->
                 <View
-                    android:layout_width="0dp"
-                    android:layout_height="32dp"
-                    android:layout_marginHorizontal="4dp"
-                    android:layout_weight="1"
-                    android:background="@drawable/shimmer_placeholder" />
+                    android:id="@+id/shimmerAvatar"
+                    android:layout_width="90dp"
+                    android:layout_height="90dp"
+                    android:layout_marginTop="24dp"
+                    android:background="@drawable/shimmer_placeholder_circle"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/shimmerBtnBack" />
 
+                <!-- Ad Soyad Placeholder -->
                 <View
-                    android:layout_width="0dp"
-                    android:layout_height="32dp"
-                    android:layout_marginHorizontal="4dp"
-                    android:layout_weight="1"
-                    android:background="@drawable/shimmer_placeholder" />
-            </LinearLayout>
+                    android:id="@+id/shimmerFullName"
+                    android:layout_width="140dp"
+                    android:layout_height="20dp"
+                    android:layout_marginStart="16dp"
+                    android:background="@drawable/shimmer_placeholder"
+                    app:layout_constraintStart_toEndOf="@id/shimmerAvatar"
+                    app:layout_constraintTop_toTopOf="@id/shimmerAvatar" />
 
-            <!-- Biyografi Placeholder -->
-            <View
-                android:id="@+id/shimmerBio1"
-                android:layout_width="180dp"
-                android:layout_height="14dp"
-                android:layout_marginTop="16dp"
-                android:background="@drawable/shimmer_placeholder"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/shimmerAvatar" />
-
-            <View
-                android:id="@+id/shimmerBio2"
-                android:layout_width="240dp"
-                android:layout_height="14dp"
-                android:layout_marginTop="6dp"
-                android:background="@drawable/shimmer_placeholder"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/shimmerBio1" />
-
-            <!-- Buton Placeholder -->
-            <View
-                android:id="@+id/shimmerButton"
-                android:layout_width="0dp"
-                android:layout_height="42dp"
-                android:layout_marginTop="16dp"
-                android:background="@drawable/shimmer_placeholder"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/shimmerBio2" />
-
-            <!-- Gönderiler Grid Placeholder -->
-            <LinearLayout
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                android:layout_marginTop="20dp"
-                android:orientation="vertical"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/shimmerButton">
-
+                <!-- Sayılar Placeholder -->
                 <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="120dp"
-                    android:layout_marginBottom="4dp"
-                    android:orientation="horizontal">
+                    android:id="@+id/shimmerStats"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginTop="12dp"
+                    android:orientation="horizontal"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/shimmerAvatar"
+                    app:layout_constraintTop_toBottomOf="@id/shimmerFullName">
 
                     <View
                         android:layout_width="0dp"
-                        android:layout_height="match_parent"
-                        android:layout_marginEnd="2dp"
+                        android:layout_height="32dp"
+                        android:layout_marginHorizontal="4dp"
                         android:layout_weight="1"
                         android:background="@drawable/shimmer_placeholder" />
 
                     <View
                         android:layout_width="0dp"
-                        android:layout_height="match_parent"
-                        android:layout_marginHorizontal="2dp"
+                        android:layout_height="32dp"
+                        android:layout_marginHorizontal="4dp"
                         android:layout_weight="1"
                         android:background="@drawable/shimmer_placeholder" />
 
                     <View
                         android:layout_width="0dp"
-                        android:layout_height="match_parent"
-                        android:layout_marginStart="2dp"
+                        android:layout_height="32dp"
+                        android:layout_marginHorizontal="4dp"
                         android:layout_weight="1"
                         android:background="@drawable/shimmer_placeholder" />
                 </LinearLayout>
 
+                <!-- Biyografi Placeholder -->
+                <View
+                    android:id="@+id/shimmerBio1"
+                    android:layout_width="180dp"
+                    android:layout_height="14dp"
+                    android:layout_marginTop="16dp"
+                    android:background="@drawable/shimmer_placeholder"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/shimmerAvatar" />
+
+                <View
+                    android:id="@+id/shimmerBio2"
+                    android:layout_width="240dp"
+                    android:layout_height="14dp"
+                    android:layout_marginTop="6dp"
+                    android:background="@drawable/shimmer_placeholder"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/shimmerBio1" />
+
+                <!-- Buton Placeholder -->
+                <View
+                    android:id="@+id/shimmerButton"
+                    android:layout_width="0dp"
+                    android:layout_height="42dp"
+                    android:layout_marginTop="16dp"
+                    android:background="@drawable/shimmer_placeholder"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/shimmerBio2" />
+
+                <!-- Gönderiler Grid Placeholder -->
                 <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="120dp"
-                    android:orientation="horizontal">
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:layout_marginTop="20dp"
+                    android:orientation="vertical"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/shimmerButton">
 
-                    <View
-                        android:layout_width="0dp"
-                        android:layout_height="match_parent"
-                        android:layout_marginEnd="2dp"
-                        android:layout_weight="1"
-                        android:background="@drawable/shimmer_placeholder" />
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="120dp"
+                        android:layout_marginBottom="4dp"
+                        android:orientation="horizontal">
 
-                    <View
-                        android:layout_width="0dp"
-                        android:layout_height="match_parent"
-                        android:layout_marginHorizontal="2dp"
-                        android:layout_weight="1"
-                        android:background="@drawable/shimmer_placeholder" />
+                        <View
+                            android:layout_width="0dp"
+                            android:layout_height="match_parent"
+                            android:layout_marginEnd="2dp"
+                            android:layout_weight="1"
+                            android:background="@drawable/shimmer_placeholder" />
 
-                    <View
-                        android:layout_width="0dp"
-                        android:layout_height="match_parent"
-                        android:layout_marginStart="2dp"
-                        android:layout_weight="1"
-                        android:background="@drawable/shimmer_placeholder" />
+                        <View
+                            android:layout_width="0dp"
+                            android:layout_height="match_parent"
+                            android:layout_marginHorizontal="2dp"
+                            android:layout_weight="1"
+                            android:background="@drawable/shimmer_placeholder" />
+
+                        <View
+                            android:layout_width="0dp"
+                            android:layout_height="match_parent"
+                            android:layout_marginStart="2dp"
+                            android:layout_weight="1"
+                            android:background="@drawable/shimmer_placeholder" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="120dp"
+                        android:orientation="horizontal">
+
+                        <View
+                            android:layout_width="0dp"
+                            android:layout_height="match_parent"
+                            android:layout_marginEnd="2dp"
+                            android:layout_weight="1"
+                            android:background="@drawable/shimmer_placeholder" />
+
+                        <View
+                            android:layout_width="0dp"
+                            android:layout_height="match_parent"
+                            android:layout_marginHorizontal="2dp"
+                            android:layout_weight="1"
+                            android:background="@drawable/shimmer_placeholder" />
+
+                        <View
+                            android:layout_width="0dp"
+                            android:layout_height="match_parent"
+                            android:layout_marginStart="2dp"
+                            android:layout_weight="1"
+                            android:background="@drawable/shimmer_placeholder" />
+                    </LinearLayout>
                 </LinearLayout>
-            </LinearLayout>
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </com.facebook.shimmer.ShimmerFrameLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </com.facebook.shimmer.ShimmerFrameLayout>
 
-    <!-- GERÇEK İÇERİK -->
-    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-        android:id="@+id/swipeRefreshLayout"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="visible">
-
+        <!-- 2. GERÇEK İÇERİK LAYOUT -->
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/myConstraintLayout"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:padding="16dp">
+            android:padding="16dp"
+            android:visibility="visible">
 
             <!-- Geri Butonu -->
             <ImageButton
@@ -216,7 +217,7 @@
                 app:layout_constraintTop_toTopOf="parent"
                 app:tint="#000000" />
 
-            <!-- KULLANICI ADI (Geri Butonunun Yanına Taşındı) -->
+            <!-- KULLANICI ADI -->
             <TextView
                 android:id="@+id/KullaniciAdi"
                 android:layout_width="0dp"
@@ -262,7 +263,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/btnBack" />
 
-            <!-- AD SOYAD (Eski KullaniciAdi Yeri) -->
+            <!-- AD SOYAD -->
             <TextView
                 android:id="@+id/tvAdSoyad"
                 android:layout_width="0dp"
@@ -290,7 +291,6 @@
                 app:layout_constraintStart_toEndOf="@id/profilFotoImageView"
                 app:layout_constraintTop_toBottomOf="@id/tvAdSoyad">
 
-                <!-- Gönderi -->
                 <LinearLayout
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
@@ -314,7 +314,6 @@
                         android:textSize="12sp" />
                 </LinearLayout>
 
-                <!-- Takipçi -->
                 <LinearLayout
                     android:id="@+id/takipciSayisiLayout"
                     android:layout_width="0dp"
@@ -339,7 +338,6 @@
                         android:textSize="12sp" />
                 </LinearLayout>
 
-                <!-- Takip -->
                 <LinearLayout
                     android:id="@+id/takipEdilenSayisiLayout"
                     android:layout_width="0dp"
@@ -474,37 +472,38 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:gravity="center_vertical"
-                android:visibility="visible"
                 android:orientation="horizontal"
-                app:layout_constraintTop_toBottomOf="@id/buttonBarrier"
+                android:visibility="visible"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent">
+                app:layout_constraintTop_toBottomOf="@id/buttonBarrier">
 
                 <View
                     android:layout_width="0dp"
                     android:layout_height="1dp"
                     android:layout_weight="1"
-                    android:background="#E6E6E6"/>
+                    android:background="#E6E6E6" />
 
                 <TextView
                     android:id="@+id/gonderilerBaslikTextView"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="14dp"
-                    android:text="GÖNDERİLER"
-                    android:textStyle="bold"
-                    android:textSize="12sp"
-                    android:textColor="#666666"
+                    android:fontFamily="sans-serif-medium"
                     android:letterSpacing="0.10"
-                    android:fontFamily="sans-serif-medium"/>
+                    android:text="GÖNDERİLER"
+                    android:textColor="#666666"
+                    android:textSize="12sp"
+                    android:textStyle="bold" />
 
                 <View
                     android:layout_width="0dp"
                     android:layout_height="1dp"
                     android:layout_weight="1"
-                    android:background="#E6E6E6"/>
+                    android:background="#E6E6E6" />
 
             </LinearLayout>
+
             <ProgressBar
                 android:id="@+id/progressBarr"
                 android:layout_width="40dp"
@@ -512,9 +511,9 @@
                 android:layout_marginTop="24dp"
                 android:indeterminate="true"
                 android:visibility="gone"
-                app:layout_constraintTop_toBottomOf="@id/postSectionHeader"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent" />
+                app:layout_constraintTop_toBottomOf="@id/postSectionHeader" />
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/gonderiRecyclerView"
@@ -546,6 +545,76 @@
                 app:layout_constraintTop_toTopOf="@id/gonderiRecyclerView" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
-    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-</FrameLayout>
+        <!-- 3. ENGEL EKRANI LAYOUT (ARTIK SWIPEREFRESH YAPISI İÇİNDE) -->
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/blockedUserLayout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@android:color/white"
+            android:padding="16dp"
+            android:visibility="gone">
+
+            <!-- Geri Butonu -->
+            <ImageButton
+                android:id="@+id/btnBackEngel"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="Geri Dön"
+                android:src="?attr/homeAsUpIndicator"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:tint="#000000" />
+
+            <!-- KULLANICI ADI -->
+            <TextView
+                android:id="@+id/KullaniciAdiEngel"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:text="kullanici_adi"
+                android:textColor="#000000"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toBottomOf="@id/btnBackEngel"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/btnBackEngel"
+                app:layout_constraintTop_toTopOf="@id/btnBackEngel" />
+
+            <!-- Ekran Ortasında Uyarı Mesajları -->
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:orientation="vertical"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Bu kullanıcı sizi engelledi."
+                    android:textColor="#444444"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:gravity="center"
+                    android:paddingHorizontal="24dp"
+                    android:text="Bu profile erişemezsiniz."
+                    android:textColor="#888888"
+                    android:textSize="14sp" />
+            </LinearLayout>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </FrameLayout>
+</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>


### PR DESCRIPTION
## Fixes #64

### **Summary**
Fixes an issue where the profile picture, biography, and counts failed to render on a fresh app install until a manual swipe-to-refresh was performed.

### **Changes Made**
* **Unified State Management:** Refactored `GetProfileFullDataUseCase` to retrieve all profile details, post caches, and counts within a single consolidated `FullProfileData` state.
* **Firestore Read Optimization:** Consolidated profile attributes, follow stats, and post counts into a single document read (`users/{userId}`) in `ProfileRepository`.
* **Streamlined UI:** Updated `ProfilFragment` to bind all header data directly from `fullProfileState` on the initial render.

### **Verification**
- [x] Performed a clean install and logged in.
- [x] Navigated to Profile tab; verified image, bio, and counts render instantly without requiring a pull-to-refresh.